### PR TITLE
Removing 'simulate' flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - sudo apt-get update -qq
 
   # Remove MySQL. Completely and totally.
-  - sudo apt-get remove --purge -s 'mysql*'
+  - sudo apt-get remove --purge 'mysql*'
   - sudo apt-get autoremove
   - sudo apt-get autoclean
   - sudo rm -rf /var/lib/mysql


### PR DESCRIPTION
Hi there,

I don't know if it's intended, but the '-s' flag just simulates the purge of the packages. I was having some problems with this trying to install percona.

Kind regards, Simon.
