### PR TITLE
Ensure apt cache is updated before install.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,8 @@
   apt: >
     name={{ item }}
     state=installed
+    update_cache=yes
+    cache_valid_time=3600
   with_items: mysql_packages
   when: ansible_os_family == 'Debian'
 


### PR DESCRIPTION
Without cache being up to date, apt is unable to fetch packages from the
internet and an error is thrown.

If, in case, the cache is updated in a separate task in another role
preceding this one; the update is not executed. There is an hour of
acceptable cache time, meaning that if within an hour, an update on
cache was made; the update is ignored for that task.

Having the cache updated, fixes problems on package installation and
ensures this role works without any problem nor any additional step if
the cache is already up to date.
