### PR TITLE
Add the libselinux-python package for RedHat.

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,3 +4,4 @@ mysql_packages:
   - mysql
   - mysql-server
   - MySQL-python
+  - libselinux-python 


### PR DESCRIPTION
When I switched the base box to chef/centos-6.6, I got the error "Aborting, target uses selinux but python bindings (libselinux-python) aren't installed!" and this fixes it.