### PR TITLE
Adhere to the Debian idioms more closely for some config values.

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -2,7 +2,7 @@
 - name: Copy my.cnf global MySQL configuration.
   template:
     src: my.cnf.j2
-    dest: /etc/my.cnf
+    dest: "{{ mysql_config_file_path }}"
     owner: root
     group: root
     mode: 0644

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,3 +3,5 @@ mysql_daemon: mysql
 mysql_packages:
   - mysql-server
   - python-mysqldb
+mysql_config_file_path: /etc/mysql/conf.d/ansible-overrides.cnf
+mysql_socket: /var/run/mysqld/mysqld.sock

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,3 +4,5 @@ mysql_packages:
   - mysql
   - mysql-server
   - MySQL-python
+mysql_config_file_path: /etc/my.cnf
+mysql_socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
I'm not even sure this role works properly on Debian/Ubuntu currently, because the init scripts look for `/etc/mysql/my.cnf` but the role actually writes to `/etc/my.cnf`.  This should address that, among with some other minor things.

`/etc/mysql/my.cnf` by default does an "include" of `/etc/mysql/conf.d/*.cnf` so rather than writing the main config file, I changed the Debian version of the role to write to the `conf.d/` directory.

Finally, I changed the default `mysql_socket` value based on the distro.

