### PR TITLE
More correctly and automatically support running the role as a user other than root

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ None.
 
 Available variables are listed below, along with default values (see `vars/main.yml`):
 
-    mysql_user_home: /root
+    mysql_user_home: <home directory of the ansible user>
 
-The home directory inside which Python MySQL settings will be stored, which Ansible will use when connecting to MySQL. This should be the home directory of the user which runs this Ansible role.
+The home directory inside which Python MySQL settings will be stored, which Ansible will use when connecting to MySQL. This should be the home directory of the user which runs this Ansible role, which the default value should take care of automatically.
 
     mysql_root_password: root
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-mysql_user_home: /root
+mysql_user_home: "~{{ ansible_ssh_user }}"
 mysql_root_username: root
 mysql_root_password: root
 

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -5,4 +5,5 @@
     collation: "{{ item.collation | default('utf8_general_ci') }}"
     encoding: "{{ item.encoding | default('utf8') }}"
     state: present
+  sudo: no
   with_items: mysql_databases

--- a/tasks/replication.yml
+++ b/tasks/replication.yml
@@ -6,6 +6,7 @@
     password: "{{ mysql_replication_user.password }}"
     priv: "{{ mysql_replication_user.priv | default('*.*:REPLICATION SLAVE') }}"
     state: present
+  sudo: no
   when: >
     (mysql_replication_role == 'master')
     and mysql_replication_user
@@ -13,6 +14,7 @@
 
 - name: Check slave replication status.
   mysql_replication: mode=getslave
+  sudo: no
   ignore_errors: true
   register: slave
   when: >
@@ -21,6 +23,7 @@
 
 - name: Check master replication status.
   mysql_replication: mode=getmaster
+  sudo: no
   delegate_to: "{{ mysql_replication_master }}"
   register: master
   when: >
@@ -36,6 +39,7 @@
     master_password: "{{ mysql_replication_user.password }}"
     master_log_file: "{{ master.File }}"
     master_log_pos: "{{ master.Position }}"
+  sudo: no
   ignore_errors: True
   when: >
     slave|failed
@@ -45,6 +49,7 @@
 
 - name: Start replication.
   mysql_replication: mode=startslave
+  sudo: no
   when: >
     slave|failed
     and (mysql_replication_role == 'slave')

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -10,6 +10,7 @@
     name: "root"
     host: "{{ item }}"
     password: "{{ mysql_root_password }}"
+  sudo: no
   with_items:
     - 127.0.0.1
     - ::1
@@ -21,12 +22,14 @@
   template:
     src: "python-my.cnf.j2"
     dest: "{{ mysql_user_home }}/.my.cnf"
-    owner: root
-    group: root
+    owner: "{{ ansible_ssh_user }}"
     mode: 0600
+  sudo: no
 
 - name: Remove anonymous MySQL user.
   mysql_user: "name='' state=absent"
+  sudo: no
 
 - name: Remove MySQL test database.
   mysql_db: "name='test' state=absent"
+  sudo: no

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -6,4 +6,5 @@
     password: "{{ item.password }}"
     priv: "{{ item.priv | default('*.*:USAGE') }}"
     state: present
+  sudo: no
   with_items: mysql_users


### PR DESCRIPTION
I use a special sudo user to run ansible, rather than a root user.  Since Ansible modules like _mysql_user_ read credentials from `$HOME/.my.cnf` but the role tasks could be in sudo mode, the modules are always trying to read from `/root/.my.cnf` regardless of the actual ansible user or `mysql_user_home` rolevar.  This works great when you happen to be using the root user anyway, but otherwise, problems.

This hopes to address that.
