### PR TITLE
Disallow remote mysql root connections

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,8 @@ mysql_user_home: /root
 mysql_root_username: root
 mysql_root_password: root
 
+mysql_disallow_remote_root: false
+
 mysql_enabled_on_startup: yes
 
 # update my.cnf. each time role is run? yes | no

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -1,4 +1,10 @@
 ---
+- name: disallow remote mysql root connections
+  when: mysql_disallow_remote_root == True
+  mysql_user: name=root host={{ item }} state=absent
+  with_items:
+    - "{{ ansible_fqdn }}"
+
 - name: Get list of hosts for the root user.
   command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = "root" ORDER BY (Host="localhost") ASC'
   register: mysql_root_hosts


### PR DESCRIPTION
This PR adds feature to disallow remote mysql root connections so we can fight mysql root brutforcing.