### PR TITLE
Replace Ubuntu init.d script

### DIFF
--- a/files/etc/init.d/mysql
+++ b/files/etc/init.d/mysql
@@ -1,0 +1,182 @@
+#!/bin/bash
+#
+### BEGIN INIT INFO
+# Provides:          mysql
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Should-Start:      $network $time
+# Should-Stop:       $network $time
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start/ Stop MySQL Community Server daemon
+# Description:       This service script facilitates startup and shutdown of
+#                    mysqld daemon throught its wrapper script mysqld_safe
+### END INIT INFO
+#
+
+# Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+#
+# Modified:
+# get_pcount() used to return 2 hits, one for the mysqld process, and one for
+# the grep for the mysqld process.  However, 5% - 10% of the time, the grep
+# line does not appear, and it appears more common when run under ansible.
+# This caused incorrect behaviour for start, stop, and status.
+# Modified get_pcount to filter out the grep line, so that 1 process count
+# signals that mysqld is running.
+
+. /lib/lsb/init-functions
+
+cd /
+umask 077
+
+MYSQLDATA=/var/lib/mysql
+VERSION=$(mysqld --version | grep mysqld | cut -d' ' -f4)
+
+get_pcount () {
+	PSCOUNT=$(ps -ef | grep "/usr/sbin/mysqld" | grep -v "grep" | wc -l)
+	echo "${PSCOUNT}"
+}
+
+server_stop () {
+	PSCOUNT=$(get_pcount)
+	COUNT=0
+	while :; do
+		COUNT=$(( COUNT+1 ))
+		echo -n .
+		if [ "${PSCOUNT}" -eq 0 ];
+		then
+			echo
+			break
+		fi
+		if [ "${COUNT}" -gt 15 ];
+		then
+			echo
+			return 1
+		fi
+		PSCOUNT=$(get_pcount)
+		sleep 1
+	done
+	return 0
+}
+
+case "$1" in
+  'start')
+	PSCOUNT=$(get_pcount)
+	if [ "${PSCOUNT}" -ge 1 ];
+	then
+		log_action_msg "A MySQL Server is already started"
+	else
+		MYSQLRUN=/var/run/mysqld
+		MYSQLDATA=/var/lib/mysql
+		MYSQLLOG=/var/log/mysql
+
+		if [ ! -d ${MYSQLDATA} -a ! -L ${MYSQLDATA} ];
+		then
+			mkdir ${MYSQLDATA}
+			chown mysql:mysql ${MYSQLDATA}
+			chmod 750 ${MYSQLDATA}
+		fi
+
+		if [ ! -d "${MYSQLDATA}/mysql" -a ! -L "${MYSQLDATA}/mysql" ];
+		then
+			mkdir ${MYSQLDATA}/mysql
+			chown mysql:mysql ${MYSQLDATA}/mysql
+			chmod 750 ${MYSQLDATA}/mysql
+		fi
+
+		if [ ! "$(ls -A ${MYSQLDATA}/mysql)" ];
+		then
+			mysql_install_db --user=mysql > /dev/null
+		fi
+
+		if [ ! -d ${MYSQLLOG} -a ! -L ${MYSQLLOG} ];
+		then
+			mkdir ${MYSQLLOG}
+			chown mysql:adm ${MYSQLLOG}
+			chmod 750 ${MYSQLLOG}
+			touch ${MYSQLLOG}/error.log
+			chmod 640 ${MYSQLLOG}/error.log
+			chown mysql:adm ${MYSQLLOG}/error.log
+		fi
+
+		if [ ! -d "${MYSQLRUN}" -a ! -L "${MYSQLRUN}" ];
+		then
+			mkdir ${MYSQLRUN}
+			chown mysql:mysql ${MYSQLRUN}
+			chmod 755 ${MYSQLRUN}
+		fi
+
+		/lib/init/apparmor-profile-load usr.sbin.mysqld
+
+		su - mysql -s /bin/bash -c "mysqld_safe > /dev/null &"
+		for i in 1 2 3 4 5 6;
+		do
+			sleep 1
+			echo -n .
+		done
+		echo
+		PSCOUNT=$(get_pcount)
+		if [ "${PSCOUNT}" -ge 1 ];
+		then
+			log_action_msg "MySQL Community Server ${VERSION} is started"
+		else
+			log_action_msg "MySQL Community Server ${VERSION} did not start. Please check logs for more details."
+		fi
+	fi
+	;;
+
+  'stop')
+	PSCOUNT=$(get_pcount)
+	if [ "${PSCOUNT}" -ge 1 ];
+	then
+		killall -15 mysqld
+		server_stop
+		if [ "$?" -eq 0 ];
+		then
+			log_action_msg "MySQL Community Server ${VERSION} is stopped"
+		else
+			log_action_msg "Attempt to shutdown MySQL Community Server ${VERSION} timed out"
+		fi
+	else
+		log_action_msg "MySQL Community Server ${VERSION} is already stopped"
+	fi
+	;;
+
+  'restart'|'reload'|'force-reload')
+	log_action_msg "Stopping MySQL Community Server ${VERSION}"
+	$0 stop
+	log_action_msg "Re-starting MySQL Community Server ${VERSION}"
+	$0 start
+	;;
+
+  'status')
+	PSCOUNT=$(get_pcount)
+	if [ ${PSCOUNT} -ge 1 ];
+	then
+		log_action_msg "MySQL Community Server ${VERSION} is running"
+	else
+		log_action_msg "MySQL Community Server ${VERSION} is not running"
+		exit 3
+	fi
+	;;
+
+  *)
+	echo "Usage: $SELF start|stop|restart|reload|force-reload|status"
+	exit 1
+	;;
+esac
+
+exit 0

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check if MySQL is already installed.
-  stat: path=/etc/init.d/mysql
+  stat: path=/usr/sbin/mysqld
   register: mysql_installed
 
 - name: Update apt cache if MySQL is not yet installed.
@@ -11,6 +11,16 @@
   apt: "name={{ item }} state=installed"
   with_items: mysql_packages
 
+- name: Replace default MySQL init.d script
+  copy:
+    src: etc/init.d/mysql
+    dest: /etc/init.d/mysql
+    owner: root
+    group: root
+    mode: 0755
+    backup: yes
+  when: mysql_installed.stat.exists == false
+
 # Because Ubuntu starts MySQL as part of the install process, we need to stop
 # mysql and remove the logfiles in case the user set a custom log file size.
 - name: Ensure MySQL is stopped after initial install.
@@ -20,3 +30,4 @@
 - name: Delete innodb log files created by apt package after initial install.
   shell: "rm -f {{ mysql_datadir }}/ib_logfile[01]"
   when: mysql_installed.stat.exists == false
+


### PR DESCRIPTION
This fixes random issues running provisioning for a Vagrant VM with Ubuntu 14.04 and mysql-community-server 5.6.25-1ubuntu12.04.

/etc/init.d/mysql greps for the mysql process to determine if mysql is running. When running, the process count includes the mysqld process and the grep for that process (count=2). When running under vagrant using ansible to provision, 5% - 10% of the time the grep is not in the process list, causing false negatives when detecting the mysqld process is running. When provisioning, this results in refusing to stop the service and failing to start the service.

This new init script ignores the grep process, making the run detection more reliable.

Submitted upstream as http://bugs.mysql.com/bug.php?id=77696