### PR TITLE
eliminates extra whitespace in the variable value

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Define mysql_daemon.
   set_fact:
-    mysql_daemon: "{{ __mysql_daemon }} "
+    mysql_daemon: "{{ __mysql_daemon }}"
   when: mysql_daemon is not defined
 
 # Setup/install tasks.


### PR DESCRIPTION
On ubuntu 14.04, removing this extra whitespace cleared an error that was halting ansible at line 25 of tasks/configure.yml.