### PR TITLE
Add variables for innodb large prefix

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,6 +57,8 @@ mysql_innodb_log_file_size: "64M"
 mysql_innodb_log_buffer_size: "8M"
 mysql_innodb_flush_log_at_trx_commit: "1"
 mysql_innodb_lock_wait_timeout: 50
+mysql_innodb_file_format: "Antelope"
+mysql_innodb_large_prefix: "OFF"
 
 # mysqldump settings.
 mysql_mysqldump_max_allowed_packet: "64M"

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -88,6 +88,8 @@ innodb_log_file_size = {{ mysql_innodb_log_file_size }}
 innodb_log_buffer_size = {{ mysql_innodb_log_buffer_size }}
 innodb_flush_log_at_trx_commit = {{ mysql_innodb_flush_log_at_trx_commit }}
 innodb_lock_wait_timeout = {{ mysql_innodb_lock_wait_timeout }}
+innodb_file_format = {{ mysql_innodb_file_format }}
+innodb_large_prefix = {{ mysql_innodb_large_prefix }}
 
 [mysqldump]
 quick


### PR DESCRIPTION
For utf8mb4 encoding. see https://www.pagerduty.com/blog/trading-up-your-engine-how-to-move-your-iops-heavy-mysqlrails-stack-to-unicode-without-downtime/