### PR TITLE
reversed order of mysql-python install

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,8 +1,8 @@
 ---
-- name: Ensure MySQL Python libraries are installed.
-  yum: "name=MySQL-python state=installed enablerepo={{ mysql_enablerepo }}"
-
 - name: Ensure MySQL packages are installed.
   yum: "name={{ item }} state=installed enablerepo={{ mysql_enablerepo }}"
   with_items: mysql_packages
   register: rh_mysql_install_packages
+
+- name: Ensure MySQL Python libraries are installed.
+  yum: "name=MySQL-python state=installed enablerepo={{ mysql_enablerepo }}"


### PR DESCRIPTION
MySQL-python has a dependency of mysql-libs.  If MySQL-python is installed before mysql, mysql-libs will be installed. However, when installing mysql56u (for example) and other versions of mysql, a mysql56u-libs is installed which conflicts with mysql-libs.  

By installing mysql(version) first, mysql(version)-libs will satisfy the requirement for MySQL-python and no conflict arises.

This PR just swaps the order of the install so that MySQL-python is installed after the packages.