### PR TITLE
Disallow root login remotely

### DIFF
--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -1,4 +1,10 @@
 ---
+- name: Disallow root login remotely
+  command: 'mysql -NBe "{{ item }}"'
+  with_items:
+    - DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1')
+  changed_when: False
+
 - name: Get list of hosts for the root user.
   command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = "root" ORDER BY (Host="localhost") ASC'
   register: mysql_root_hosts


### PR DESCRIPTION
When installing mysql56u (and assumedly others), updating the root password on domain.com fails (it says the user does not exist!), at a minimum in vagrant. I have not tested using a box with a valid hostname.   I suspect it has something to do with the fact that it is trying to resolve the hostname and the hostname doesn't exist (updating /etc/hosts doesn't solve, nor does the mysql skip_name_resolve option).

However, the bigger issue, from a security perspective, is that a machine hostname could be changed, resulting in root access from another machine.  

Both of the above issues are solved by simply removing any root user that that doesn't come from localhost, which this PR does.  

Note: doing a "drop user"  fails for the same DNS reasons.