### PR TITLE
Set pidfile even when not running via mysqld_safe

### DIFF
--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -8,6 +8,7 @@ port = {{ mysql_port }}
 bind-address = {{ mysql_bind_address }}
 datadir = {{ mysql_datadir }}
 socket = {{ mysql_socket }}
+pid-file = {{ mysql_pid_file }}
 
 # Logging configuration.
 {% if mysql_log_error == 'syslog' or mysql_log == 'syslog' %}


### PR DESCRIPTION
For example, Ubuntu 14.04 /etc/init.d/mysql does not use mysqld_safe
and parses the pidfile out of `mysqld --print-defaults` instead.

---

Without this change:

```
Server version: 5.5.46-0ubuntu0.14.04.2 (Ubuntu)

mysql> show variables like '%pid%';
+---------------+---------------------------------+
| Variable_name | Value                           |
+---------------+---------------------------------+
| pid_file      | /var/lib/mysql/ansible-test.pid |
+---------------+---------------------------------+
```

```
$ /usr/sbin/mysqld --print-defaults | tr ' ' '\n' | grep pid
<no output>
```

With this change:

```
Server version: 5.5.46-0ubuntu0.14.04.2 (Ubuntu)

mysql> show variables like '%pid%';
+---------------+----------------------------+
| Variable_name | Value                      |
+---------------+----------------------------+
| pid_file      | /var/run/mysqld/mysqld.pid |
+---------------+----------------------------+
```

```
$ /usr/sbin/mysqld --print-defaults | tr ' ' '\n' | grep pid
--pid-file=/var/run/mysqld/mysqld.pid
```

And of course the new pid file location is actually used as well, which is useful for monitoring mysqld using e.g. [monit](https://mmonit.com/monit/).