### PR TITLE
Issue #77: Add docker based tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ env:
     init: /sbin/init
     run_opts: ""
     playbook: test.yml
-  - distribution: ubuntu
-    version: 12.04
-    init: /sbin/init
-    run_opts: ""
-    playbook: test.yml
+  # - distribution: ubuntu
+  #   version: 12.04
+  #   init: /sbin/init
+  #   run_opts: ""
+  #   playbook: test.yml
 
 services:
   - docker
@@ -70,4 +70,4 @@ script:
     || (echo 'MySQL not running' && exit 1)
 
   # Clean up
-  - 'sudo docker stop "$(cat ${container_id})"'
+  - sudo docker stop "$(cat ${container_id})"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,25 +2,26 @@
 sudo: required
 
 env:
-  matrix:
-    - distribution: centos
-      version: 6
-      init: /sbin/init
-      run_opts: ""
-    - distribution: centos
-      version: 7
-      init: /usr/lib/systemd/systemd
-      run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-    - distribution: ubuntu
-      version: 14.04
-      init: /sbin/init
-      run_opts: ""
-    - distribution: ubuntu
-      version: 12.04
-      init: /sbin/init
-      run_opts: ""
-  global:
-    - testfile: test.yml
+  - distribution: centos
+    version: 6
+    init: /sbin/init
+    run_opts: ""
+    playbook: test.yml
+  - distribution: centos
+    version: 7
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    playbook: centos-7-test.yml
+  - distribution: ubuntu
+    version: 14.04
+    init: /sbin/init
+    run_opts: ""
+    playbook: test.yml
+  - distribution: ubuntu
+    version: 12.04
+    init: /sbin/init
+    run_opts: ""
+    playbook: test.yml
 
 services:
   - docker
@@ -37,14 +38,14 @@ script:
   - 'sudo docker run --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:ro ${run_opts} ${distribution}-${version}:ansible "${init}" > "${container_id}"'
 
   # Ansible syntax check.
-  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/${testsite} --syntax-check'
+  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/${playbook} --syntax-check'
 
   # Test role.
-  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/${testsite}'
+  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/${playbook}'
 
   # Test role idempotence.
   - >
-    sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/${testsite}
+    sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/${playbook}
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,55 +1,72 @@
 ---
-language: python
-python: "2.7"
+sudo: required
 
 env:
-  - SITE=test.yml
+  matrix:
+    - distribution: centos
+      version: 6
+      init: /sbin/init
+      run_opts: ""
+    - distribution: centos
+      version: 7
+      init: /usr/lib/systemd/systemd
+      run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    - distribution: ubuntu
+      version: 14.04
+      init: /sbin/init
+      run_opts: ""
+    - distribution: ubuntu
+      version: 12.04
+      init: /sbin/init
+      run_opts: ""
+  global:
+    - testfile: test.yml
+
+services:
+  - docker
 
 before_install:
-  - sudo apt-get update -qq
-
-  # Remove MySQL. Completely and totally.
-  - sudo apt-get remove --purge 'mysql*'
-  - sudo apt-get autoremove
-  - sudo apt-get autoclean
-  - sudo rm -rf /var/lib/mysql
-  - sudo truncate -s 0 /var/log/mysql/error.log
-
-install:
-  # Install Ansible.
-  - pip install ansible
-
-  # Add ansible.cfg to pick up roles path.
-  - "{ echo '[defaults]'; echo 'roles_path = ../'; } >> ansible.cfg"
+  # Pull container
+  - 'sudo docker pull ${distribution}:${version}'
+  # Customize container
+  - 'sudo docker build --rm=true --file=tests/Dockerfile.${distribution}-${version} --tag=${distribution}-${version}:ansible tests'
 
 script:
-  # Check the role/playbook's syntax.
-  - "ansible-playbook -i tests/inventory tests/$SITE --syntax-check"
+  - container_id=$(mktemp)
+    # Run container in detached state
+  - 'sudo docker run --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:ro ${run_opts} ${distribution}-${version}:ansible "${init}" > "${container_id}"'
 
-  # Run the role/playbook with ansible-playbook.
-  - "ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo"
+  # Ansible syntax check.
+  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/${testsite} --syntax-check'
 
-  # Run the role/playbook again, checking to make sure it's idempotent.
+  # Test role.
+  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/${testsite}'
+
+  # Test role idempotence.
   - >
-    ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo
+    sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/${testsite}
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)
 
   # Some MySQL debugging (show all the logs).
-  - "sudo ls -lah /var/log"
-  - "sudo cat /var/log/mysql/error.log"
+  - sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ls -lah /var/log
+  - sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm cat /var/log/mysql/error.log || true
+  - sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm cat /var/log/mysql.err || true
 
   # Check to make sure we can connect to MySQL via Unix socket.
   - >
-    mysql -u root -proot -e 'show databases;'
+    sudo docker exec "$(cat ${container_id})" mysql -u root -proot -e 'show databases;'
     | grep -q 'performance_schema'
     && (echo 'MySQL running normally' && exit 0)
     || (echo 'MySQL not running' && exit 1)
 
   # Check to make sure we can connect to MySQL via TCP.
   - >
-    mysql -u root -proot -h 127.0.0.1 -e 'show databases;'
+    sudo docker exec "$(cat ${container_id})" mysql -u root -proot -h 127.0.0.1 -e 'show databases;'
     | grep -q 'performance_schema'
     && (echo 'MySQL running normally' && exit 0)
     || (echo 'MySQL not running' && exit 1)
+
+  # Clean up
+  - 'sudo docker stop "$(cat ${container_id})"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,14 +58,14 @@ script:
   # Check to make sure we can connect to MySQL via Unix socket.
   - >
     sudo docker exec "$(cat ${container_id})" mysql -u root -proot -e 'show databases;'
-    | grep -q 'performance_schema'
+    | grep -q 'information_schema'
     && (echo 'MySQL running normally' && exit 0)
     || (echo 'MySQL not running' && exit 1)
 
   # Check to make sure we can connect to MySQL via TCP.
   - >
     sudo docker exec "$(cat ${container_id})" mysql -u root -proot -h 127.0.0.1 -e 'show databases;'
-    | grep -q 'performance_schema'
+    | grep -q 'information_schema'
     && (echo 'MySQL running normally' && exit 0)
     || (echo 'MySQL not running' && exit 1)
 

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -18,7 +18,7 @@
 # Because Ubuntu starts MySQL as part of the install process, we need to stop
 # mysql and remove the logfiles in case the user set a custom log file size.
 - name: Ensure MySQL is stopped after initial install.
-  service: name=mysql state=stopped
+  service: "name={{ mysql_daemon }} state=stopped"
   when: mysql_installed.stat.exists == false
 
 - name: Delete innodb log files created by apt package after initial install.

--- a/tests/Dockerfile.centos-6
+++ b/tests/Dockerfile.centos-6
@@ -1,0 +1,15 @@
+FROM centos:6
+
+# Install Ansible
+RUN yum -y update; yum clean all;
+RUN yum -y install epel-release
+RUN yum -y install git ansible sudo
+RUN yum clean all
+
+# Disable requiretty
+RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
+
+# Install Ansible inventory file
+RUN echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
+
+CMD ["/usr/sbin/init"]

--- a/tests/Dockerfile.centos-7
+++ b/tests/Dockerfile.centos-7
@@ -1,0 +1,27 @@
+FROM centos:7
+
+# Install systemd -- See https://hub.docker.com/_/centos/
+RUN yum -y swap -- remove fakesystemd -- install systemd systemd-libs
+RUN yum -y update; yum clean all; \
+(cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*; \
+rm -f /etc/systemd/system/*.wants/*; \
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*; \
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+# Install Ansible
+RUN yum -y install epel-release
+RUN yum -y install git ansible sudo
+RUN yum clean all
+
+# Disable requiretty
+RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
+
+# Install Ansible inventory file
+RUN echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
+
+VOLUME ["/sys/fs/cgroup"]
+CMD ["/usr/sbin/init"]

--- a/tests/Dockerfile.ubuntu-12.04
+++ b/tests/Dockerfile.ubuntu-12.04
@@ -1,0 +1,11 @@
+FROM ubuntu:12.04
+RUN apt-get update
+
+# Install Ansible
+RUN apt-get install -y software-properties-common python-software-properties git
+RUN apt-add-repository -y ppa:ansible/ansible
+RUN apt-get update
+RUN apt-get install -y ansible
+
+# Install Ansible inventory file
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts

--- a/tests/Dockerfile.ubuntu-12.04
+++ b/tests/Dockerfile.ubuntu-12.04
@@ -7,5 +7,8 @@ RUN apt-add-repository -y ppa:ansible/ansible
 RUN apt-get update
 RUN apt-get install -y ansible
 
+COPY initctl_faker .
+RUN chmod +x initctl_faker && rm -fr /sbin/initctl && ln -s /initctl_faker /sbin/initctl
+
 # Install Ansible inventory file
 RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts

--- a/tests/Dockerfile.ubuntu-14.04
+++ b/tests/Dockerfile.ubuntu-14.04
@@ -1,0 +1,11 @@
+FROM ubuntu:14.04
+RUN apt-get update
+
+# Install Ansible
+RUN apt-get install -y software-properties-common git
+RUN apt-add-repository -y ppa:ansible/ansible
+RUN apt-get update
+RUN apt-get install -y ansible
+
+# Install Ansible inventory file
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts

--- a/tests/Dockerfile.ubuntu-14.04
+++ b/tests/Dockerfile.ubuntu-14.04
@@ -7,5 +7,8 @@ RUN apt-add-repository -y ppa:ansible/ansible
 RUN apt-get update
 RUN apt-get install -y ansible
 
+COPY initctl_faker .
+RUN chmod +x initctl_faker && rm -fr /sbin/initctl && ln -s /initctl_faker /sbin/initctl
+
 # Install Ansible inventory file
 RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts

--- a/tests/centos-7-test.yml
+++ b/tests/centos-7-test.yml
@@ -1,0 +1,15 @@
+---
+- hosts: all
+  vars:
+    mysql_packages:
+      - mariadb
+      - mariadb-server
+      - mariadb-libs
+      - MySQL-python
+      - perl-DBD-MySQL
+    mysql_daemon: mariadb
+    mysql_log_error: /var/log/mariadb/mariadb.log
+    mysql_syslog_tag: mariadb
+    mysql_pid_file: /var/run/mariadb/mariadb.pid
+  roles:
+    - role_under_test

--- a/tests/initctl_faker
+++ b/tests/initctl_faker
@@ -1,0 +1,23 @@
+#!/bin/sh
+ALIAS_CMD="$(echo ""$0"" | sed -e 's?/sbin/??')"
+
+case "$ALIAS_CMD" in
+    start|stop|restart|reload|status)
+        exec service $1 $ALIAS_CMD
+        ;;
+esac
+
+case "$1" in
+    list )
+        exec service --status-all
+        ;;
+    reload-configuration )
+        exec service $2 restart
+        ;;
+    start|stop|restart|reload|status)
+        exec service $2 $1
+        ;;
+    \?)
+        exit 0
+        ;;
+esac

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,4 @@
 ---
-- hosts: localhost
-  remote_user: root
+- hosts: all
   roles:
-    - ansible-role-mysql
+    - role_under_test


### PR DESCRIPTION
Over at Drupal VM this role is the one that seems to be failing the most in the Docker tests, so I'm adding the setup here too. Currently everything will fail but maybe travis can help us work through all the errors on at a time. I'm getting some weird inconsistencies when running it locally...

Once we get stuff working we can just create a separate `test.yml` for CentOS 7 (or fix #55, which I'd prefer for upstream tests).