### PR TITLE
Add password fileds for blank passwords on CentOS 7 and MariaDB

### DIFF
--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -1,12 +1,12 @@
 ---
 - name: Disallow root login remotely
-  command: 'mysql -NBe "{{ item }}"'
-  with_items:
-    - DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1')
+  command: >
+    mysql -uroot --password='' -NBe "DELETE FROM mysql.user WHERE User='root'
+    AND Host NOT IN ('localhost', '127.0.0.1', '::1')"
   changed_when: False
 
 - name: Get list of hosts for the root user.
-  command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = "root" ORDER BY (Host="localhost") ASC'
+  command: mysql -uroot --password='' -NBe 'SELECT Host FROM mysql.user WHERE User = "root" ORDER BY (Host="localhost") ASC'
   register: mysql_root_hosts
   changed_when: false
 
@@ -14,7 +14,7 @@
 # the root password correctly. See: https://goo.gl/MSOejW
 - name: Update MySQL root password for localhost root account.
   shell: >
-    mysql -u root -NBe
+    mysql -u root --password='' -NBe
     'SET PASSWORD FOR "{{ mysql_root_username }}"@"{{ item }}" = PASSWORD("{{ mysql_root_password }}");'
   with_items: "{{ mysql_root_hosts.stdout_lines }}"
   when: mysql_install_packages | bool or mysql_root_password_update


### PR DESCRIPTION
Found that blank passwords now need to be specified as ''.