### PR TITLE
add no_log to operation on confidential data

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -8,3 +8,4 @@
     state: present
     append_privs: "{{ item.append_privs | default('no') }}"
   with_items: "{{ mysql_users }}"
+  no_log: true


### PR DESCRIPTION
Without no_log, password would appear in node's syslog.
It's probably unwanted when it comes to password