### PR TITLE
lets mysql_db defines the default encoding

### DIFF
--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -2,7 +2,7 @@
 - name: Ensure MySQL databases are present.
   mysql_db:
     name: "{{ item.name }}"
-    collation: "{{ item.collation | default('utf8_general_ci') }}"
-    encoding: "{{ item.encoding | default('utf8') }}"
+    collation: "{{ item.collation | default(omit) }}"
+    encoding: "{{ item.encoding | default(omit) }}"
     state: present
   with_items: "{{ mysql_databases }}"


### PR DESCRIPTION
cf:
- https://docs.ansible.com/ansible/playbooks_filters.html#omitting-undefined-variables-and-parameters
- https://docs.ansible.com/ansible/playbooks_filters.html#omitting-undefined-variables-and-parameters
  Lets machine default apply. They probably are the best of all the possible defaults.
