### PR TITLE
don't fail in --check mode

### DIFF
--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -16,7 +16,7 @@
   shell: >
     mysql -u root -NBe
     'SET PASSWORD FOR "{{ mysql_root_username }}"@"{{ item }}" = PASSWORD("{{ mysql_root_password }}");'
-  with_items: "{{ mysql_root_hosts.stdout_lines }}"
+  with_items: "{{ mysql_root_hosts.stdout_lines | default([]) }}"
   when: mysql_install_packages | bool or mysql_root_password_update
 
 # Has to be after the root password assignment, for idempotency.


### PR DESCRIPTION
In check-mode, mysql_root_hosts is an object containing `{'skipped': True}`
The when condition apply for *each* item (thus it does not prevent task execution, even if the with_items parameter isn't an array (the `when` will be run `mysql_root_hosts.stdout_lines | count` times).
Thus in --check mode, and to avoid an error, we need to set a valid (an noop) default value)