### PR TITLE
don't create root-owned files inside a directory for which we ignore the owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ No special requirements; note that this role requires root access, so either run
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-    mysql_user_home: /root
+    mysql_user: root
 
-The home directory inside which Python MySQL settings will be stored, which Ansible will use when connecting to MySQL. This should be the home directory of the user which runs this Ansible role.
+The user in the home directory of whom .my.cnf settings will be stored, which Ansible will use when connecting to MySQL. This should be the home directory of the user which runs this Ansible role.
 
     mysql_root_password: root
 
@@ -29,7 +29,7 @@ The MySQL root user account password.
 
 Whether to force update the MySQL root user's password. By default, this role will only change the root user's password when MySQL is first configured. You can force an update by setting this to `yes`.
 
-> Note: If you get an error like `ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES)` after a failed or interrupted playbook run, this usually means the root password wasn't originally updated to begin with. Try either removing  the `.my.cnf` file inside the configured `mysql_user_home` or updating it and setting `password=''` (the insecure default password). Run the playbook again, with `mysql_root_password_update` set to `yes`, and the setup should complete.
+> Note: If you get an error like `ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES)` after a failed or interrupted playbook run, this usually means the root password wasn't originally updated to begin with. Try either removing  the `.my.cnf` file inside the home directory of  `mysql_user` or updating it and setting `password=''` (the insecure default password). Run the playbook again, with `mysql_root_password_update` set to `yes`, and the setup should complete.
 
     mysql_enabled_on_startup: yes
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-mysql_user_home: /root
+mysql_user: root
 mysql_root_username: root
 mysql_root_password: root
 

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -6,3 +6,4 @@
     encoding: "{{ item.encoding | default('utf8') }}"
     state: present
   with_items: "{{ mysql_databases }}"
+  become: "{{ mysql_user }}"

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -23,15 +23,15 @@
 - name: Copy .my.cnf file with root password credentials.
   template:
     src: "user-my.cnf.j2"
-    dest: "{{ mysql_user_home }}/.my.cnf"
-    owner: root
-    group: root
+    dest: ~/.my.cnf
+    user: "{{ mysql_user }}"
     mode: 0600
 
 - name: Get list of hosts for the anonymous user.
   command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = ""'
   register: mysql_anonymous_hosts
   changed_when: false
+  become: "{{ mysql_user }}"
 
 - name: Remove anonymous MySQL users.
   mysql_user:
@@ -39,6 +39,8 @@
      host: "{{ item }}"
      state: absent
   with_items: "{{ mysql_anonymous_hosts.stdout_lines }}"
+  become: "{{ mysql_user }}"
 
 - name: Remove MySQL test database.
   mysql_db: "name='test' state=absent"
+  become: "{{ mysql_user }}"

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -8,3 +8,4 @@
     state: present
     append_privs: "{{ item.append_privs | default('no') }}"
   with_items: "{{ mysql_users }}"
+  become: "{{ mysql_user }}"


### PR DESCRIPTION
don't create root-owned files inside a directory for which we ignore the owner
But just ask for a user then let `become` and '~' find it's HOME automatically.
Then execute further mysql_\* actions by `becoming such a`{{mysql_user}}`

Note: revisit this when Ansible 2.0 introduces `config_file` for mysql_\* operations.
