### PR TITLE
ansible doesn't have a create-if-not-exists

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -30,7 +30,7 @@
   notify: restart mysql
 
 - name: Create slow query log file (if configured).
-  file: "path={{ mysql_slow_query_log_file }} state=touch"
+  shell: "touch {{ mysql_slow_query_log_file }} creates={{ mysql_slow_query_log_file }}"
   when: mysql_slow_query_log_enabled
 
 - name: Set ownership on slow query log file (if configured).


### PR DESCRIPTION
We shouldn't be changing the date each time this is run.  While this doesn't make a difference on an installation run, it does make a difference if you are tracking changes.