### PR TITLE
More correctly and automatically support running the role as a user other than root

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,14 @@
 ---
 mysql_user_home: /root
+mysql_user_name: root
+mysql_user_password: root
+mysql_root_home: /root
 mysql_root_username: root
 mysql_root_password: root
 
 # Set this to `yes` to forcibly update the root password.
 mysql_root_password_update: no
+mysql_user_password_update: no
 
 mysql_enabled_on_startup: yes
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,11 @@
 ---
+# Set this to the user ansible is logging in as - should have root
+# or sudo access
 mysql_user_home: /root
 mysql_user_name: root
 mysql_user_password: root
+
+# The default root user installed by mysql - almost always root
 mysql_root_home: /root
 mysql_root_username: root
 mysql_root_password: root

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -1,20 +1,39 @@
 ---
+- name: Ensure default user is present.
+  mysql_user:
+    name: "{{ mysql_user_name }}"
+    host: 'localhost'
+    password: "{{ mysql_user_password }}"
+    priv: '*.*:ALL,GRANT'
+    state: present
+  when: mysql_user_name != mysql_root_username
+
+# Has to be after the password assignment, for idempotency.
+- name: Copy user-my.cnf file with password credentials.
+  template:
+    src: "user-my.cnf.j2"
+    dest: "{{ mysql_user_home }}/.my.cnf"
+    owner: "{{ mysql_user_name }}"
+    mode: 0600
+  when: mysql_user_name != mysql_root_username and (mysql_install_packages | bool or mysql_user_password_update)
+
 - name: Disallow root login remotely
   command: 'mysql -NBe "{{ item }}"'
   with_items:
-    - DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1')
+    - DELETE FROM mysql.user WHERE User='{{ mysql_root_username }}' AND Host NOT IN ('localhost', '127.0.0.1', '::1')
   changed_when: False
 
 - name: Get list of hosts for the root user.
-  command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = "root" ORDER BY (Host="localhost") ASC'
+  command: mysql -NBe "SELECT Host FROM mysql.user WHERE User = '{{ mysql_root_username }}' ORDER BY (Host='localhost') ASC"
   register: mysql_root_hosts
   changed_when: false
+  when: mysql_install_packages | bool or mysql_root_password_update
 
 # Note: We do not use mysql_user for this operation, as it doesn't always update
 # the root password correctly. See: https://goo.gl/MSOejW
 - name: Update MySQL root password for localhost root account.
   shell: >
-    mysql -u root -NBe
+    mysql -NBe
     'SET PASSWORD FOR "{{ mysql_root_username }}"@"{{ item }}" = PASSWORD("{{ mysql_root_password }}");'
   with_items: "{{ mysql_root_hosts.stdout_lines }}"
   when: mysql_install_packages | bool or mysql_root_password_update
@@ -22,11 +41,12 @@
 # Has to be after the root password assignment, for idempotency.
 - name: Copy .my.cnf file with root password credentials.
   template:
-    src: "user-my.cnf.j2"
-    dest: "{{ mysql_user_home }}/.my.cnf"
+    src: "root-my.cnf.j2"
+    dest: "{{ mysql_root_home }}/.my.cnf"
     owner: root
     group: root
     mode: 0600
+  when: mysql_install_packages | bool or mysql_root_password_update
 
 - name: Get list of hosts for the anonymous user.
   command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = ""'

--- a/templates/root-my.cnf.j2
+++ b/templates/root-my.cnf.j2
@@ -1,0 +1,3 @@
+[client]
+user={{ mysql_root_username }}
+password={{ mysql_root_password }}

--- a/templates/user-my.cnf.j2
+++ b/templates/user-my.cnf.j2
@@ -1,3 +1,3 @@
 [client]
-user={{ mysql_root_username }}
-password={{ mysql_root_password }}
+user={{ mysql_user_name }}
+password={{ mysql_user_password }}


### PR DESCRIPTION
This is an alternate to https://github.com/geerlingguy/ansible-role-mysql/pull/13.  It should be backwards compatible.  However, if the user runs as a user other than root, it creates a root user in mysql for that user and deploys the appropriate my.cnf. 
