### PR TITLE
Fix "when" statement for mysql error log file permissions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,9 @@ script:
   # Test role.
   - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/${playbook}'
 
+  # Test role again.
+  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/${playbook}'
+
   # Test role idempotence.
   - >
     sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/${playbook}

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -53,7 +53,7 @@
     owner: mysql
     group: mysql
     mode: 0644
-  when: mysql_slow_query_log_enabled
+  when: mysql_log == "" and mysql_log_error != ""
 
 - name: Ensure MySQL is started and enabled on boot.
   service: "name={{ mysql_daemon }} state=started enabled={{ mysql_enabled_on_startup }}"


### PR DESCRIPTION
This is causing failures on my CentOS7 tests for devshop:

https://travis-ci.org/opendevshop/devshop/jobs/126429109#L1705

The error log file is created but permissions are skipped because they are conditional on `mysql_slow_query_log_enabled`, which I assume was a mistake?

Thanks!
