### PR TITLE
remove requirement of redhat-lsb-core

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
   when: ansible_os_family != "RedHat"
 
 - name: Include OS-specific variables (RedHat).
-  include_vars: "{{ ansible_os_family }}-{{ ansible_lsb.major_release }}.yml"
+  include_vars: "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
   when: ansible_os_family == "RedHat"
 
 - name: Define mysql_packages.


### PR DESCRIPTION
I would suggest to use {{ ansible_distribution_major_version }} instead of the {{ ansible_lsb.major_release }} since that will require the package redhat-lsb-core installed which is not always installed. You will get the same result if you use the other way without the requirement of redhat-lsb-core package.