### PR TITLE
Add mysql tmpdir directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The MySQL users and their privileges. A user has the values `name`, `host` (defa
     mysql_port: "3306"
     mysql_bind_address: '0.0.0.0'
     mysql_datadir: /var/lib/mysql
+    mysql_tmpdir: /tmp
 
 Default MySQL connection configuration.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,7 @@ mysql_bind_address: '0.0.0.0'
 mysql_datadir: /var/lib/mysql
 mysql_pid_file: /var/run/mysqld/mysqld.pid
 mysql_skip_name_resolve: no
+mysql_tmpdir: /tmp
 
 # Slow query log settings.
 mysql_slow_query_log_enabled: no

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -42,6 +42,15 @@
     mode:  0755
     setype: mysqld_db_t
 
+- name: Create tmpdir if it does not exist
+  file:
+    path: "{{ mysql_tmpdir }}"
+    state: directory
+    owner: mysql
+    group: mysql
+    mode: 0755
+  when: mysql_tmpdir != "/tmp"
+
 - name: Set ownership on slow query log file (if configured).
   file:
     path: "{{ mysql_slow_query_log_file }}"

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -12,6 +12,7 @@ pid-file = {{ mysql_pid_file }}
 {% if mysql_skip_name_resolve %}
 skip-name-resolve
 {% endif %}
+tmpdir = {{ mysql_tmpdir }}
 
 # Logging configuration.
 {% if mysql_log_error == 'syslog' or mysql_log == 'syslog' %}


### PR DESCRIPTION
Add missing directive to customize tmpdir.
Default is /tmp, link in all mysql installation
