### PR TITLE
add mysql_binlog_format directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The rest of the settings in `defaults/main.yml` control MySQL's memory usage. Th
 
     mysql_server_id: "1"
     mysql_max_binlog_size: "100M"
-    mysql_binlog_format: "STATEMENT"
+    mysql_binlog_format: "ROW"
     mysql_expire_logs_days: "10"
     mysql_replication_role: ''
     mysql_replication_master: ''

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The rest of the settings in `defaults/main.yml` control MySQL's memory usage. Th
 
     mysql_server_id: "1"
     mysql_max_binlog_size: "100M"
+    mysql_binlog_format: "STATEMENT"
     mysql_expire_logs_days: "10"
     mysql_replication_role: ''
     mysql_replication_master: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -88,7 +88,7 @@ mysql_users: []
 # Replication settings (replication is only enabled if master/user have values).
 mysql_server_id: "1"
 mysql_max_binlog_size: "100M"
-mysql_binlog_format: "STATEMENT"
+mysql_binlog_format: "ROW"
 mysql_expire_logs_days: "10"
 mysql_replication_role: ''
 mysql_replication_master: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -88,6 +88,7 @@ mysql_users: []
 # Replication settings (replication is only enabled if master/user have values).
 mysql_server_id: "1"
 mysql_max_binlog_size: "100M"
+mysql_binlog_format: "STATEMENT"
 mysql_expire_logs_days: "10"
 mysql_replication_role: ''
 mysql_replication_master: ''

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -40,6 +40,7 @@ log_bin = mysql-bin
 log-bin-index = mysql-bin.index
 expire_logs_days = {{ mysql_expire_logs_days }}
 max_binlog_size = {{ mysql_max_binlog_size }}
+binlog_format = {{binlog_format}}
 
 {% for db in mysql_databases %}
 {% if db.replicate|default(1) %}

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -40,7 +40,7 @@ log_bin = mysql-bin
 log-bin-index = mysql-bin.index
 expire_logs_days = {{ mysql_expire_logs_days }}
 max_binlog_size = {{ mysql_max_binlog_size }}
-binlog_format = {{binlog_format}}
+binlog_format = {{mysql_binlog_format}}
 
 {% for db in mysql_databases %}
 {% if db.replicate|default(1) %}


### PR DESCRIPTION
Some application (owncloud in my case) require to use a different binlog_format than the mysql default (statement), so it could be nice to have the opportunity change it directly from your role! 

So I simply added the variable mysql_binlog_format (with a default value of STATEMENT, which is the default for mysql and mariadb)

This change has been tested on CentOS7 and Ubuntu!

Best regards,
Erkax