### PR TITLE
Fix role failing in check mode

### DIFF
--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -9,6 +9,7 @@
   command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = "root" ORDER BY (Host="localhost") ASC'
   register: mysql_root_hosts
   changed_when: false
+  always_run: true
 
 # Note: We do not use mysql_user for this operation, as it doesn't always update
 # the root password correctly. See: https://goo.gl/MSOejW
@@ -32,6 +33,7 @@
   command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = ""'
   register: mysql_anonymous_hosts
   changed_when: false
+  always_run: true
 
 - name: Remove anonymous MySQL users.
   mysql_user:


### PR DESCRIPTION
If the role is run in check mode, the shell commands never get executed
and the variables used in the next task are undefined, causing the play
to fail.

The commands are now always executed to ensure the variables are
populated.