### PR TITLE
Allow RedHat-7 variables to be overridden.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,21 @@
     mysql_slow_query_log_file: "{{ __mysql_slow_query_log_file }}"
   when: mysql_slow_query_log_file is not defined
 
+- name: Define mysql_log_error.
+  set_fact:
+    mysql_log_error: "{{ __mysql_log_error }}"
+  when: mysql_log_error is not defined
+
+- name: Define mysql_syslog_tag.
+  set_fact:
+    mysql_syslog_tag: "{{ __mysql_syslog_tag }}"
+  when: mysql_syslog_tag is not defined
+
+- name: Define mysql_pid_file.
+  set_fact:
+    mysql_pid_file: "{{ __mysql_pid_file }}"
+  when: mysql_pid_file is not defined
+
 # Setup/install tasks.
 - include: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'

--- a/vars/RedHat-7.yml
+++ b/vars/RedHat-7.yml
@@ -7,9 +7,9 @@ __mysql_packages:
   - MySQL-python
   - perl-DBD-MySQL
 __mysql_slow_query_log_file: /var/log/mysql-slow.log
-mysql_log_error: /var/log/mariadb/mariadb.log
-mysql_syslog_tag: mariadb
-mysql_pid_file: /var/run/mariadb/mariadb.pid
+__mysql_log_error: /var/log/mariadb/mariadb.log
+__mysql_syslog_tag: mariadb
+__mysql_pid_file: /var/run/mariadb/mariadb.pid
 mysql_config_file: /etc/my.cnf
 mysql_config_include_dir: /etc/my.cnf.d
 mysql_socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
The file `/vars/RedHat-7.yml` overrides the `mysql_log_error` variable to: "`/var/log/mariadb/mariadb.log`". _This variable can not be overwritten by users of the role._

On my CentOS 7 systems I use the mariaDB packages rather than the CentOS ones so the `/var/log/mariadb` directory does not exist so the `configure.yml` playbook fails when trying to touch that file:
`fatal: [server1]: FAILED! => {"changed": true, "cmd": "touch /var/log/mariadb/mariadb.log", "delta": "0:00:00.004271", "end": "2016-06-14 08:47:03.630648", "failed": true, "rc": 1, "start": "2016-06-14 08:47:03.626377", "stderr": "touch: cannot touch '/var/log/mariadb/mariadb.log': No such file or directory", "stdout": "", "stdout_lines": [], "warnings": ["Consider using file module with state=touch rather than running touch"]}`