### PR TITLE
character-set-server = utf8mb4

### DIFF
--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -2,10 +2,14 @@
 #password = your_password
 port = {{ mysql_port }}
 socket = {{ mysql_socket }}
+default-character-set = {{ mysql_default-character-set }}
 
 [mysqld]
 port = {{ mysql_port }}
 bind-address = {{ mysql_bind_address }}
+character-set-client-handshake = {{ mysql_character-set-client-handshake }}
+character-set-server = {{ mysql_default-character-set }}
+collation-server = {{ mysql_collation-server }}
 datadir = {{ mysql_datadir }}
 socket = {{ mysql_socket }}
 pid-file = {{ mysql_pid_file }}


### PR DESCRIPTION
Debian MySQL 5.5.49 was warning that 4 byte utf8 was not enabled - utf8mb4 characters set enables this. Suppressing warning only important in our case in that it marked Aegir tasks with warnings.