### PR TITLE
add option for a global/default charset

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ The rest of the settings in `defaults/main.yml` control MySQL's memory usage and
 
 Replication settings. Set `mysql_server_id` and `mysql_replication_role` by server (e.g. the master would be ID `1`, with the `mysql_replication_role` of `master`, and the slave would be ID `2`, with the `mysql_replication_role` of `slave`). The `mysql_replication_user` uses the same keys as `mysql_users`, and is created on master servers, and used to replicate on all the slaves.
 
+    mysql_default_charset: "utf8"
+
+MySQL character-set configuration. Defaults are not using this, if you want to configure a global character-set you have to provide a accepted value according to the mysql documentation.
+
 ### MariaDB usage
 
 This role works with either MySQL or a compatible version of MariaDB. On RHEL/CentOS 7+, the mariadb database engine was substituted as the default MySQL replacement package. No modifications are necessary though all of the variables still reference 'mysql' instead of mariadb.

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -2,6 +2,9 @@
 #password = your_password
 port = {{ mysql_port }}
 socket = {{ mysql_socket }}
+{% if mysql_default_charset|default(None) %}
+default-character-set = {{ mysql_default_charset }}
+{% endif %}
 
 [mysqld]
 port = {{ mysql_port }}
@@ -11,6 +14,9 @@ socket = {{ mysql_socket }}
 pid-file = {{ mysql_pid_file }}
 {% if mysql_skip_name_resolve %}
 skip-name-resolve
+{% endif %}
+{% if mysql_default_charset|default(None) %}
+character-set-server = {{ mysql_default_charset }}
 {% endif %}
 
 # Logging configuration.


### PR DESCRIPTION
i know, that the list for `mysql_databases` does allow `encoding` as well as `collation` - but that is only applied on a per-database level.

i wanted my mysql server to apply a global/default charset for everything. didn't have an option for that yet, so i've tried to add one. i did leave out a setting for `defaults/main.yml` on purpose, using `|default(None)` in the templates to check if a value does exist at all.

if you like to be it another way, let me know @geerlingguy 