### PR TITLE
Auto-create .my.cnf file with default pass, if and only if it is necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The MySQL root user account password.
 
 Whether to force update the MySQL root user's password. By default, this role will only change the root user's password when MySQL is first configured. You can force an update by setting this to `yes`.
 
-> Note: If you get an error like `ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES)` after a failed or interrupted playbook run, this usually means the root password wasn't originally updated to begin with. Try either removing  the `.my.cnf` file inside the configured `mysql_user_home` or updating it and setting `password=''` (the insecure default password). Run the playbook again, with `mysql_root_password_update` set to `yes`, and the setup should complete.
+> Note: If you get an error like `ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES)` after a failed or interrupted playbook run, this usually means the root password wasn't originally updated to begin with. Try either removing  the `.my.cnf` file inside the configured `mysql_user_home` or updating it and setting `password=''` (the insecure default password). Run the playbook again, with `mysql_root_password_update` set to `yes`, and the setup should complete. This playbook will attempt to do this for you automatically if necessary.
 
     mysql_enabled_on_startup: yes
 

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -4,16 +4,6 @@
   register: mysql_cli_version
   changed_when: false
 
-# Note: This has to be here before the first attempt to connect to mysql shell or it fails on first run
-- name: Create /root/.my.cnf file from template if and only if it doesn't exist already
-  template:
-    src: "first-run-temp-my.cnf.j2"
-    dest: "{{ mysql_user_home }}/.my.cnf"
-    owner: root
-    group: root
-    mode: 0600
-    force: no
-
 - name: Disallow root login remotely
   command: 'mysql -NBe "{{ item }}"'
   with_items:

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -4,6 +4,16 @@
   register: mysql_cli_version
   changed_when: false
 
+# Note: This has to be here before the first attempt to connect to mysql shell or it fails on first run
+- name: Create /root/.my.cnf file from template if and only if it doesn't exist already
+  template:
+    src: "first-run-temp-my.cnf.j2"
+    dest: "{{ mysql_user_home }}/.my.cnf"
+    owner: root
+    group: root
+    mode: 0600
+    force: no
+
 - name: Disallow root login remotely
   command: 'mysql -NBe "{{ item }}"'
   with_items:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -27,3 +27,14 @@
           - "ib_logfile0"
           - "ib_logfile1"
   when: mysql_installed.stat.exists == false
+
+  
+# Note: This has to be here before the first attempt to connect to mysql shell or it fails on first run
+- name: Create /root/.my.cnf file from template if and only if it doesn't exist already
+  template:
+    src: "first-run-temp-my.cnf.j2"
+    dest: "{{ mysql_user_home }}/.my.cnf"
+    owner: root
+    group: root
+    mode: 0600
+    force: no

--- a/templates/first-run-temp-my.cnf.j2
+++ b/templates/first-run-temp-my.cnf.j2
@@ -1,0 +1,3 @@
+[client]
+user={{ mysql_root_username }}
+password=""


### PR DESCRIPTION
Hey Jeff - first, thank you for sharing this awesome playbook.

Your note in the README mentions:

> "Note: If you get an error like ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES) after a failed or interrupted playbook run"

I found that I got that error every time on my system and it was definitely not due to being interrupted as is against stable local VMs:

- Controller / Virtual Box Host: Mac El Capitan 10.11.5 (15F34)
- Target Virtual Box Guest: Ubuntu Server 14.04 64 Bit
- ansible 2.1.1.0

I've automated your solution of creating a temporary .my.cnf with a blank root password (if and only if it doesn't exist) which then gets overwritten later. Making that behaviour part of the playbook seems cleaner and works great for me on initial and repeat test runs.