### PR TITLE
allow mysql_users to be also defined in a dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The MySQL databases to create. A database has the values `name`, `encoding` (def
 
     mysql_users: []
 
-The MySQL users and their privileges. A user has the values `name`, `host` (defaults to `localhost`), `password`, `priv` (defaults to `*.*:USAGE`), `append_privs` (defaults to `no`),  `state`  (defaults to `present`). The formats of these are the same as in the `mysql_user` module.
+The MySQL users and their privileges. A user has the values `name`, `host` (defaults to `localhost`), `password`, `priv` (defaults to `*.*:USAGE`), `append_privs` (defaults to `no`),  `state`  (defaults to `present`). The formats of these are the same as in the `mysql_user` module. Alternatively the `mysql_users` may be defined in a dictionary with the user name as key.
 
     mysql_packages:
       - mysql

--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ None.
         password: similarly-secure-password
         priv: "example_db.*:ALL"
 
+MySQL users may also be defined as dictionary
+
+    mysql_users:
+      example_user:
+        host: "%"
+        password: similarly-secure-password
+        priv: "example_db.*:ALL"
+
 ## License
 
 MIT / BSD

--- a/tasks/users-dict.yml
+++ b/tasks/users-dict.yml
@@ -1,0 +1,11 @@
+---
+- name: Ensure MySQL users are present.
+  mysql_user:
+    name: "{{ item.value.name | default(item.key) }}"
+    host: "{{ item.value.host | default('localhost') }}"
+    password: "{{ item.value.password }}"
+    priv: "{{ item.value.priv | default('*.*:USAGE') }}"
+    state: "{{ item.value.state | default('present') }}"
+    append_privs: "{{ item.value.append_privs | default('no') }}"
+  with_dict: "{{ mysql_users }}"
+  no_log: true

--- a/tasks/users-list.yml
+++ b/tasks/users-list.yml
@@ -1,0 +1,11 @@
+---
+- name: Ensure MySQL users are present.
+  mysql_user:
+    name: "{{ item.name }}"
+    host: "{{ item.host | default('localhost') }}"
+    password: "{{ item.password }}"
+    priv: "{{ item.priv | default('*.*:USAGE') }}"
+    state: "{{ item.state | default('present') }}"
+    append_privs: "{{ item.append_privs | default('no') }}"
+  with_items: "{{ mysql_users }}"
+  no_log: true

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,24 +1,6 @@
 ---
-- name: Ensure MySQL users are present.
-  mysql_user:
-    name: "{{ item.name }}"
-    host: "{{ item.host | default('localhost') }}"
-    password: "{{ item.password }}"
-    priv: "{{ item.priv | default('*.*:USAGE') }}"
-    state: "{{ item.state | default('present') }}"
-    append_privs: "{{ item.append_privs | default('no') }}"
-  with_items: "{{ mysql_users }}"
-  when: mysql_users.0 is defined
-  no_log: true
+- include: "users-list.yml"
+  when: mysql_users is not mapping
 
-- name: Ensure MySQL users are present.
-  mysql_user:
-    name: "{{ item.value.name | default(item.key) }}"
-    host: "{{ item.value.host | default('localhost') }}"
-    password: "{{ item.value.password }}"
-    priv: "{{ item.value.priv | default('*.*:USAGE') }}"
-    state: "{{ item.value.state | default('present') }}"
-    append_privs: "{{ item.value.append_privs | default('no') }}"
-  with_dict: "{{ mysql_users }}"
-  when: mysql_users.0 is not defined
-  no_log: true
+- include: "users-dict.yml"
+  when: mysql_users is mapping

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -13,7 +13,7 @@
 
 - name: Ensure MySQL users are present.
   mysql_user:
-    name: "{{ item.key }}"
+    name: "{{ item.value.name | default(item.key) }}"
     host: "{{ item.value.host | default('localhost') }}"
     password: "{{ item.value.password }}"
     priv: "{{ item.value.priv | default('*.*:USAGE') }}"

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -8,4 +8,17 @@
     state: "{{ item.state | default('present') }}"
     append_privs: "{{ item.append_privs | default('no') }}"
   with_items: "{{ mysql_users }}"
+  when: mysql_users.0 is defined
+  no_log: true
+
+- name: Ensure MySQL users are present.
+  mysql_user:
+    name: "{{ item.key }}"
+    host: "{{ item.value.host | default('localhost') }}"
+    password: "{{ item.value.password }}"
+    priv: "{{ item.value.priv | default('*.*:USAGE') }}"
+    state: "{{ item.value.state | default('present') }}"
+    append_privs: "{{ item.value.append_privs | default('no') }}"
+  with_dict: "{{ mysql_users }}"
+  when: mysql_users.0 is not defined
   no_log: true


### PR DESCRIPTION
The `mysql_users` can alternatively be defined in a dict structure. Here's what the example from the Readme would look like:

    mysql_users:
      example_user:
        host: "%"
        password: similarly-secure-password
        priv: "example_db.*:ALL"