### PR TITLE
Added a gotcha note to the README when trying to login from the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Whether to force update the MySQL root user's password. By default, this role wi
 
 > Note: If you get an error like `ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES)` after a failed or interrupted playbook run, this usually means the root password wasn't originally updated to begin with. Try either removing  the `.my.cnf` file inside the configured `mysql_user_home` or updating it and setting `password=''` (the insecure default password). Run the playbook again, with `mysql_root_password_update` set to `yes`, and the setup should complete.
 
+> Note: If you get an error like `ERROR 1698 (28000): Access denied for user 'root'@'localhost' (using password: YES)` when trying to log in from the CLI you might need to run as root or sudoer.
+
     mysql_enabled_on_startup: yes
 
 Whether MySQL should be enabled on startup.


### PR DESCRIPTION
This took me about an hour of re-provisioning to figure out that it was doing the install correctly, I was just trying to run mysql from the cli as the wrong user

Signed-off-by: Jeroen v.d. Gulik jeroen@isset.nl
