### PR TITLE
Allow sql_mode to be overridden

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,7 @@ mysql_port: "3306"
 mysql_bind_address: '0.0.0.0'
 mysql_skip_name_resolve: no
 mysql_datadir: /var/lib/mysql
+mysql_sql_mode: ''
 # The following variables have a default value depending on operating system.
 # mysql_pid_file: /var/run/mysqld/mysqld.pid
 # mysql_socket: /var/lib/mysql/mysql.sock

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -12,6 +12,9 @@ pid-file = {{ mysql_pid_file }}
 {% if mysql_skip_name_resolve %}
 skip-name-resolve
 {% endif %}
+{% if mysql_sql_mode %}
+sql_mode = {{ mysql_sql_mode }}
+{% endif %}
 
 # Logging configuration.
 {% if mysql_log_error == 'syslog' or mysql_log == 'syslog' %}


### PR DESCRIPTION
This SitePoint tutorial explains our exact reasoning for needing to override this setting: https://www.sitepoint.com/quick-tip-how-to-permanently-change-sql-mode-in-mysql/
