### PR TITLE
Add compatibility with ArchLinux

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,5 +18,8 @@ galaxy_info:
     - name: Debian
       versions:
       - all
+    - name: Archlinux
+      versions:
+      - all
   galaxy_tags:
     - database

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,9 +11,13 @@
   when: ansible_os_family == 'Debian'
   static: no
 
+- include: setup-Archlinux.yml
+  when: ansible_os_family == 'Archlinux'
+  static: no
+
 - name: Check if MySQL packages were installed.
   set_fact:
-    mysql_install_packages: "{{ (rh_mysql_install_packages is defined and rh_mysql_install_packages.changed) or (deb_mysql_install_packages is defined and deb_mysql_install_packages.changed) }}"
+    mysql_install_packages: "{{ (rh_mysql_install_packages is defined and rh_mysql_install_packages.changed) or (deb_mysql_install_packages is defined and deb_mysql_install_packages.changed) or (arch_mysql_install_packages is defined and arch_mysql_install_packages.changed) }}"
 
 # Configure MySQL.
 - include: configure.yml

--- a/tasks/setup-Archlinux.yml
+++ b/tasks/setup-Archlinux.yml
@@ -1,0 +1,12 @@
+---
+- name: Ensure MySQL Python libraries are installed.
+  pacman: "name=mysql-python state=present"
+
+- name: Ensure MySQL packages are installed.
+  pacman: "name={{ item }} state=present"
+  with_items: "{{ mysql_packages }}"
+  register: arch_mysql_install_packages
+
+# Init the database if mysql is newly installed
+- command: mysql_install_db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
+  when: arch_mysql_install_packages.changed

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -1,7 +1,11 @@
 ---
 # Variable configuration.
 - name: Include OS-specific variables.
-  include_vars: "{{ ansible_os_family }}.yml"
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+      - "vars/{{ ansible_os_family }}.yml"
+      skip: true
   when: ansible_os_family != "RedHat"
 
 - name: Include OS-specific variables (RedHat).

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,0 +1,12 @@
+---
+__mysql_daemon: mariadb
+__mysql_packages:
+  - mariadb
+__mysql_slow_query_log_file: /var/log/mysql/mysql-slow.log
+__mysql_log_error: /var/log/mysql.err
+__mysql_syslog_tag: mysql
+__mysql_pid_file: /run/mysqld/mysqld.pid
+__mysql_config_file: /etc/mysql/my.cnf
+__mysql_config_include_dir: /etc/mysql/conf.d
+__mysql_socket: /run/mysqld/mysqld.sock
+__mysql_supports_innodb_large_prefix: true


### PR DESCRIPTION
Hello,
These modifications make your role compatible with Archlinux. It also extends the compatibility as the role does not break if a system does not have its variable file declared. The installation will not be done, but at least the configuration will work