### PR TITLE
Replace deprecated always_run argument

### DIFF
--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -32,7 +32,7 @@
   command: mysql -NBe "SELECT Host FROM mysql.user WHERE User = '{{ mysql_root_username }}' ORDER BY (Host='localhost') ASC"
   register: mysql_root_hosts
   changed_when: false
-  always_run: true
+  check_mode: no
   when: mysql_install_packages | bool or mysql_root_password_update
 
 # Note: We do not use mysql_user for this operation, as it doesn't always update
@@ -67,7 +67,7 @@
   command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = ""'
   register: mysql_anonymous_hosts
   changed_when: false
-  always_run: true
+  check_mode: no
 
 - name: Remove anonymous MySQL users.
   mysql_user:


### PR DESCRIPTION
With version `2.5.0` I'm getting the following error:

```
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings
can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

So it looks like a straightforward replacement.