### PR TITLE
Fix for "always_run" deprecation warning

### DIFF
--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -14,7 +14,7 @@
   command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = "root" ORDER BY (Host="localhost") ASC'
   register: mysql_root_hosts
   changed_when: false
-  always_run: true
+  check_mode: no
 
 # Note: We do not use mysql_user for this operation, as it doesn't always update
 # the root password correctly. See: https://goo.gl/MSOejW
@@ -47,7 +47,7 @@
   command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = ""'
   register: mysql_anonymous_hosts
   changed_when: false
-  always_run: true
+  check_mode: no
 
 - name: Remove anonymous MySQL users.
   mysql_user:


### PR DESCRIPTION
In ansible v2.2.1.0 getting deprecation warning:

```
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled
 by setting deprecation_warnings=False in ansible.cfg
```

This commit fixes it by replacing `always_run` with `check_mode`.