### PR TITLE
Add the event_scheduler option to my.cnf.j2 with the default value of 'OFF'

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -68,6 +68,7 @@ mysql_max_heap_table_size: "16M"
 # Other settings.
 mysql_lower_case_table_names: "0"
 mysql_wait_timeout: "28800"
+mysql_event_scheduler_state: "OFF"
 
 # InnoDB settings.
 mysql_innodb_file_per_table: "1"

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -88,6 +88,7 @@ max_heap_table_size = {{ mysql_max_heap_table_size }}
 # Other settings.
 wait_timeout = {{ mysql_wait_timeout }}
 lower_case_table_names = {{ mysql_lower_case_table_names }}
+event_scheduler = {{ mysql_event_scheduler_state }}
 
 # InnoDB settings.
 {% if mysql_supports_innodb_large_prefix %}


### PR DESCRIPTION
I added the `event_scheduler` option, because we had need of it in a project. Here are the docs for that option: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_event_scheduler. I thought it could potentially be useful to others.