### PR TITLE
Don't try to change existing MySQL

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -14,6 +14,7 @@
   apt: "name={{ item }} state=installed"
   with_items: "{{ mysql_packages }}"
   register: deb_mysql_install_packages
+  when: mysql_installed.stat.exists == false
 
 # Because Ubuntu starts MySQL as part of the install process, we need to stop
 # mysql and remove the logfiles in case the user set a custom log file size.


### PR DESCRIPTION
On Debian, we did check whether MySQL is already installed, but we tried to
install mysql_packages in any case. This fails if a non-default MySQL version
is already installed, e.g. mysql-server-5.6 on Ubuntu Trusty.

Therefore, skip package installation step if /etc/init.d/mysql exists.