### PR TITLE
Update default log-error for mysql 5.7

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -93,7 +93,7 @@ mysql_mysqldump_max_allowed_packet: "64M"
 # Logging settings.
 mysql_log: ""
 # The following variables have a default value depending on operating system.
-# mysql_log_error: /var/log/mysql.err
+# mysql_log_error: /var/log/mysql/mysql.err
 # mysql_syslog_tag: mysql
 
 mysql_config_include_files: []

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,7 +4,7 @@ __mysql_packages:
   - mysql-common
   - mysql-server
 __mysql_slow_query_log_file: /var/log/mysql/mysql-slow.log
-__mysql_log_error: /var/log/mysql.err
+__mysql_log_error: /var/log/mysql/mysql.err
 __mysql_syslog_tag: mysql
 __mysql_pid_file: /var/run/mysqld/mysqld.pid
 __mysql_config_file: /etc/mysql/my.cnf


### PR DESCRIPTION
log_error is required writable directory in MySQL 5.7

https://dev.mysql.com/doc/refman/5.7/en/error-log.html
> It is common for Yum or APT package installations to configure an error log location under /var/log with an entry like log-error=/var/log/mysqld.log in a server configuration file. Removing the file name from the entry causes the default log file to be used, which is written to the data directory.
