### PR TITLE
Correcting ERROR 1045 password:NO error

### DIFF
--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -23,9 +23,9 @@
   when: mysql_user_name != mysql_root_username and (mysql_install_packages | bool or mysql_user_password_update)
 
 - name: Disallow root login remotely
-  command: 'mysql -NBe "{{ item }}"'
+  command: 'mysql -NBe "{{ item }}" --password="{{ mysql_root_password }}"'
   with_items:
-    - DELETE FROM mysql.user WHERE User='{{ mysql_root_username }}' AND Host NOT IN ('localhost', '127.0.0.1', '::1')
+    - DELETE FROM mysql.user WHERE User='{{ mysql_root_username }}' AND Host NOT IN ('localhost', '127.0.0.1', '::1');
   changed_when: false
 
 - name: Get list of hosts for the root user.
@@ -64,7 +64,7 @@
   when: mysql_install_packages | bool or mysql_root_password_update
 
 - name: Get list of hosts for the anonymous user.
-  command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = ""'
+  command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = ""' --password="{{ mysql_root_password }}"
   register: mysql_anonymous_hosts
   changed_when: false
   check_mode: no
@@ -77,4 +77,4 @@
   with_items: "{{ mysql_anonymous_hosts.stdout_lines|default([]) }}"
 
 - name: Remove MySQL test database.
-  mysql_db: "name='test' state=absent"
+  mysql_db: "name='test' state=absent login_password='{{ mysql_root_password }}'"

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -25,8 +25,15 @@
 - name: Disallow root login remotely
   command: 'mysql -NBe "{{ item }}" --password="{{ mysql_root_password }}"'
   with_items:
-    - DELETE FROM mysql.user WHERE User='{{ mysql_root_username }}' AND Host NOT IN ('localhost', '127.0.0.1', '::1');
+    - DELETE FROM mysql.user WHERE User='{{ mysql_root_username }}' AND Host NOT IN ('localhost', '127.0.0.1', '::1')
   changed_when: false
+  when: ansible_os_family != "localhost"
+
+- name: Disallow root login remotely Test
+  command: 'mysql -NBe "{{ item }}"'
+  with_items:
+    - DELETE FROM mysql.user WHERE User='{{ mysql_root_username }}' AND Host NOT IN ('localhost', '127.0.0.1', '::1')
+  when: ansible_os_family == "localhost"
 
 - name: Get list of hosts for the root user.
   command: mysql -NBe "SELECT Host FROM mysql.user WHERE User = '{{ mysql_root_username }}' ORDER BY (Host='localhost') ASC"
@@ -68,6 +75,14 @@
   register: mysql_anonymous_hosts
   changed_when: false
   check_mode: no
+  when: ansible_os_family != "localhost"
+
+- name: Get list of hosts for the anonymous user Test.
+  command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = ""'
+  register: mysql_anonymous_hosts
+  changed_when: false
+  check_mode: no
+  when: ansible_os_family == "localhost"
 
 - name: Remove anonymous MySQL users.
   mysql_user:
@@ -78,3 +93,8 @@
 
 - name: Remove MySQL test database.
   mysql_db: "name='test' state=absent login_password='{{ mysql_root_password }}'"
+  when: ansible_os_family != "localhost"
+
+- name: Remove MySQL test database Test.
+  mysql_db: "name='test' state=absent"
+  when: ansible_os_family == "localhost"


### PR DESCRIPTION
Adding root password to each MySQL command to correct ["ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: NO)"] issue in task Update secure-installation.yml

