### PR TITLE
Allow empty sql_mode

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,7 @@ mysql_port: "3306"
 mysql_bind_address: '0.0.0.0'
 mysql_skip_name_resolve: no
 mysql_datadir: /var/lib/mysql
-mysql_sql_mode: ''
+mysql_sql_mode: false
 # The following variables have a default value depending on operating system.
 # mysql_pid_file: /var/run/mysqld/mysqld.pid
 # mysql_socket: /var/lib/mysql/mysql.sock

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -12,7 +12,7 @@ pid-file = {{ mysql_pid_file }}
 {% if mysql_skip_name_resolve %}
 skip-name-resolve
 {% endif %}
-{% if mysql_sql_mode %}
+{% if mysql_sql_mode != false %}
 sql_mode = {{ mysql_sql_mode }}
 {% endif %}
 


### PR DESCRIPTION
Some old CMS requires sql_mode = ''.
I changed default `mysql_sql_mode = ''` to `mysql_sql_mode = false`.

It can break backward compatibility if `mysql_sql_mode = ''` stored in group_vars or somewhere else `default/main.yml`.

Possible better way: add something like `mysql_sql_mode = "empty"` and add to template:
```
{% if mysql_sql_mode == 'empty' %}
sql_mode = ''
{% endif %}
```