### PR TITLE
added support for encrypted user passwords

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -7,5 +7,6 @@
     priv: "{{ item.priv | default('*.*:USAGE') }}"
     state: "{{ item.state | default('present') }}"
     append_privs: "{{ item.append_privs | default('no') }}"
+    encrypted: "{{ item.encrypted | default('no') }}"
   with_items: "{{ mysql_users }}"
   no_log: true


### PR DESCRIPTION
Hi Jeff,

I've added support for providing the encrypted password hash to your mysql_users list.

Kind regards,
Tom van Leeuwen