### PR TITLE
Add disablerepo when install on Redhat

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,7 @@ overwrite_global_mycnf: yes
 # Pass in a comma-separated list of repos to use (e.g. "remi,epel"). Used only
 # for RedHat systems (and derivatives).
 mysql_enablerepo: ""
+mysql_disablerepo: ""
 
 # Define a custom list of packages to install; if none provided, the default
 # package list from vars/[OS-family].yml will be used.

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,8 +1,8 @@
 ---
 - name: Ensure MySQL packages are installed.
-  yum: "name={{ item }} state=installed enablerepo={{ mysql_enablerepo }}"
+  yum: "name={{ item }} state=installed enablerepo={{ mysql_enablerepo }} disablerepo={{ mysql_disablerepo }}"
   with_items: "{{ mysql_packages }}"
   register: rh_mysql_install_packages
 
 - name: Ensure MySQL Python libraries are installed.
-  yum: "name=MySQL-python state=installed enablerepo={{ mysql_enablerepo }}"
+  yum: "name=MySQL-python state=installed enablerepo={{ mysql_enablerepo }} disablerepo={{ mysql_disablerepo }}"


### PR DESCRIPTION
With this pull request,  disablerepo variable is enabled when install mysql packages on Redhat.
This change enable us to install older version mysql with latest rpm.

Following playbook example install mysql5.6 with latest rpm that includes mysql5.6 and mysql5.7.

```yml
- hosts: db_server
  become: yes
  user: vagrant
  roles:
    - geerlingguy.mysql
  vars:
    - mysql_enablerepo: mysql56-community
    - mysql_disablerepo: mysql57-community
  pre_tasks:
    - name: Install the MySQL repo.
      yum:
        name: https://dev.mysql.com/get/mysql57-community-release-el6-11.noarch.rpm
        state: present
      when: ansible_os_family == "RedHat"
```