### PR TITLE
Autoselect python3-mysqldb or python-mysqldb on Debian

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -7,8 +7,17 @@
   apt: update_cache=yes
   when: mysql_installed.stat.exists == false
 
-- name: Ensure MySQL Python libraries are installed.
+- name: Fetch Python version
+  shell: python -V 2>&1 | awk '{print $2}'
+  register: python_version
+
+- name: Ensure MySQL Python2 libraries are installed.
   apt: "name=python-mysqldb state=installed"
+  when: python_version.stdout | version_compare('3.0', '<')
+
+- name: Ensure MySQL Python3 libraries are installed.
+  apt: "name=python-mysqldb state=installed"
+  when: python_version.stdout | version_compare('3.0', '>=')
 
 - name: Ensure MySQL packages are installed.
   apt: "name={{ item }} state=installed"


### PR DESCRIPTION
On Debian (Stretch at least), installing python-mysqldb fails if
current Python interpreter version >= 3. There is, however,
python3-mysqldb, which works. This commit checks for the version
and chooses which one to install.

Error messages from the playbook when Python 3.5.7 has been chosen (with `update-alternatives`):

```
INSTALLING:

# apt-get install python-mysqldb
Reading package lists... Done
Building dependency tree
Reading state information... Done
Suggested packages:
  python-egenix-mxdatetime python-mysqldb-dbg
The following NEW packages will be installed:
  python-mysqldb
0 upgraded, 1 newly installed, 0 to remove and 1 not upgraded.
Need to get 0 B/52.1 kB of archives.
After this operation, 171 kB of additional disk space will be used.
Selecting previously unselected package python-mysqldb.
(Reading database ... 41188 files and directories currently installed.)
Preparing to unpack .../python-mysqldb_1.3.7-1.1_amd64.deb ...
Unpacking python-mysqldb (1.3.7-1.1) ...
Setting up python-mysqldb (1.3.7-1.1) ...
Traceback (most recent call last):
  File "/usr/bin/pycompile", line 35, in <module>
    from debpython.version import SUPPORTED, debsorted, vrepr, \
  File "/usr/share/python/debpython/version.py", line 24, in <module>
    from ConfigParser import SafeConfigParser
ImportError: No module named 'ConfigParser'
dpkg: error processing package python-mysqldb (--configure):
 subprocess installed post-installation script returned error exit status 1
Errors were encountered while processing:
 python-mysqldb
E: Sub-process /usr/bin/dpkg returned an error code (1)

UNINSTALLING:

# apt-get purge python-mysqldb
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following packages will be REMOVED:
  python-mysqldb*
0 upgraded, 0 newly installed, 1 to remove and 1 not upgraded.
1 not fully installed or removed.
After this operation, 171 kB disk space will be freed.
Do you want to continue? [Y/n] y
(Reading database ... 41217 files and directories currently installed.)
Removing python-mysqldb (1.3.7-1.1) ...
  File "/usr/bin/pyclean", line 63
    except (IOError, OSError), e:
                             ^
SyntaxError: invalid syntax
dpkg: error processing package python-mysqldb (--remove):
 subprocess installed pre-removal script returned error exit status 1
Traceback (most recent call last):
  File "/usr/bin/pycompile", line 35, in <module>
    from debpython.version import SUPPORTED, debsorted, vrepr, \
  File "/usr/share/python/debpython/version.py", line 24, in <module>
    from ConfigParser import SafeConfigParser
ImportError: No module named 'ConfigParser'
dpkg: error while cleaning up:
 subprocess installed post-installation script returned error exit status 1
Errors were encountered while processing:
 python-mysqldb
E: Sub-process /usr/bin/dpkg returned an error code (1)
```