### PR TITLE
bugfix: selinux content mapping definition

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -123,5 +123,3 @@ mysql_replication_role: ''
 mysql_replication_master: ''
 # Same keys as `mysql_users` above.
 mysql_replication_user: []
-
-selinux: "yes"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -123,3 +123,5 @@ mysql_replication_role: ''
 mysql_replication_master: ''
 # Same keys as `mysql_users` above.
 mysql_replication_user: []
+
+selinux: "yes"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -70,6 +70,19 @@
     mode: 0640
   when: mysql_log == "" and mysql_log_error != ""
 
+- name: Install policycoreutils-python
+  package:
+    name: policycoreutils-python
+    state: latest
+  when: selinux == "yes"
+
+- name: Set context mapping definition
+  sefcontext:
+    target: '/opt/mysql(/.*)?'
+    setype: mysqld_db_t
+    state: present
+  when: selinux == "yes"
+
 - name: Ensure MySQL is started and enabled on boot.
   service: "name={{ mysql_daemon }} state=started enabled={{ mysql_enabled_on_startup }}"
   register: mysql_service_configuration

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -74,14 +74,14 @@
   package:
     name: policycoreutils-python
     state: latest
-  when: selinux == "yes"
+  when: ansible_selinux.status == "enabled"
 
 - name: Set context mapping definition
   sefcontext:
     target: '/opt/mysql(/.*)?'
     setype: mysqld_db_t
     state: present
-  when: selinux == "yes"
+  when: ansible_selinux.status == "enabled"
 
 - name: Ensure MySQL is started and enabled on boot.
   service: "name={{ mysql_daemon }} state=started enabled={{ mysql_enabled_on_startup }}"


### PR DESCRIPTION
When mysql_datadir is not defaulting and when SELinux is enabled we must context mapping definition setup to service not make an error when start. More info: //mariadb.com/kb/en/the-mariadb-library/what-to-do-if-mariadb-doesnt-start/