### PR TITLE
Use {{ ansible_managed | comment }} on templates

### DIFF
--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 [client]
 #password = your_password

--- a/templates/root-my.cnf.j2
+++ b/templates/root-my.cnf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 [client]
 user="{{ mysql_root_username }}"

--- a/templates/user-my.cnf.j2
+++ b/templates/user-my.cnf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 [client]
 user="{{ mysql_user_name }}"


### PR DESCRIPTION
This pull request fixes the problem we were having with our ansible_managed, as we have a multiline ansible_managed and only the first line gets commented.