### PR TITLE
Add a variable to permit replication when mysql service listens on a different network than ssh service

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -120,6 +120,9 @@ mysql_max_binlog_size: "100M"
 mysql_binlog_format: "ROW"
 mysql_expire_logs_days: "10"
 mysql_replication_role: ''
+# the mysql master address reachable from the slave.
 mysql_replication_master: ''
+# the mysql master server address/hostname reachable via ssh with ansible, almost always the ansible inventory hostname.
+mysql_master_hostname: "{{ mysql_replication_master }}"
 # Same keys as `mysql_users` above.
 mysql_replication_user: []

--- a/tasks/replication.yml
+++ b/tasks/replication.yml
@@ -24,7 +24,7 @@
 
 - name: Check master replication status.
   mysql_replication: mode=getmaster
-  delegate_to: "{{ mysql_replication_master }}"
+  delegate_to: "{{ mysql_master_hostname }}"
   register: master
   when: >
     ((slave.Is_Slave is defined and not slave.Is_Slave) or (slave.Is_Slave is not defined and slave|failed))


### PR DESCRIPTION
In most production cases and for security reason mysql service is usually binded on a different network than ssh. 
Prior this PR, ansible via the delegate_to under replication task can't reach the server or the slave uses a wrong master address.

This PR adds a variable to permit replication in those cases.

The default behavior is unchanged because under defaults/main.yml:

    mysql_master_hostname: "{{ mysql_replication_master }}"
  
but now mysql_master_hostname can be changed at playbook level.
