### PR TITLE
Set the min/max word characters in search indexes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -85,6 +85,10 @@ mysql_innodb_log_buffer_size: "8M"
 mysql_innodb_flush_log_at_trx_commit: "1"
 mysql_innodb_lock_wait_timeout: "50"
 
+# These settings require MySQL > 5.6.
+#mysql_innodb_ft_min_token_size: "3"
+#mysql_innodb_ft_max_token_size: "84"
+
 # These settings require MySQL > 5.5.
 mysql_innodb_large_prefix: "1"
 mysql_innodb_file_format: "barracuda"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,8 +84,6 @@ mysql_innodb_log_file_size: "64M"
 mysql_innodb_log_buffer_size: "8M"
 mysql_innodb_flush_log_at_trx_commit: "1"
 mysql_innodb_lock_wait_timeout: "50"
-mysql_innodb_ft_min_token_size: "3"
-mysql_innodb_ft_max_token_size: "84"
 
 # These settings require MySQL > 5.5.
 mysql_innodb_large_prefix: "1"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,6 +67,8 @@ mysql_tmp_table_size: "16M"
 mysql_max_heap_table_size: "16M"
 mysql_group_concat_max_len: "1024"
 mysql_join_buffer_size: "262144"
+mysql_ft_min_word_len: "4"
+mysql_ft_max_word_len: "84"
 
 # Other settings.
 mysql_lower_case_table_names: "0"
@@ -82,6 +84,8 @@ mysql_innodb_log_file_size: "64M"
 mysql_innodb_log_buffer_size: "8M"
 mysql_innodb_flush_log_at_trx_commit: "1"
 mysql_innodb_lock_wait_timeout: "50"
+mysql_innodb_ft_min_token_size: "3"
+mysql_innodb_ft_max_token_size: "84"
 
 # These settings require MySQL > 5.5.
 mysql_innodb_large_prefix: "1"

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -91,6 +91,12 @@ group_concat_max_len = {{ mysql_group_concat_max_len }}
 join_buffer_size = {{ mysql_join_buffer_size }}
 ft_min_word_len = {{ mysql_ft_min_word_len }}
 ft_max_word_len = {{ mysql_ft_max_word_len }}
+{% if mysql_innodb_ft_min_token_size is defined and mysql_innodb_ft_min_token_size != None %}
+innodb_ft_min_token_size = {{ mysql_innodb_ft_min_token_size }}
+{% endif %}
+{% if mysql_innodb_ft_max_token_size is defined and mysql_innodb_ft_max_token_size != None %}
+innodb_ft_max_token_size = {{ mysql_innodb_ft_max_token_size }}
+{% endif %}
 
 # Other settings.
 wait_timeout = {{ mysql_wait_timeout }}

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -89,6 +89,10 @@ tmp_table_size = {{ mysql_tmp_table_size }}
 max_heap_table_size = {{ mysql_max_heap_table_size }}
 group_concat_max_len = {{ mysql_group_concat_max_len }}
 join_buffer_size = {{ mysql_join_buffer_size }}
+innodb_ft_min_token_size = {{ mysql_innodb_ft_min_token_size }}
+innodb_ft_max_token_size = {{ mysql_innodb_ft_max_token_size }}
+ft_min_word_len = {{ mysql_ft_min_word_len }}
+ft_max_word_len = {{ mysql_ft_max_word_len }}
 
 # Other settings.
 wait_timeout = {{ mysql_wait_timeout }}

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -89,8 +89,6 @@ tmp_table_size = {{ mysql_tmp_table_size }}
 max_heap_table_size = {{ mysql_max_heap_table_size }}
 group_concat_max_len = {{ mysql_group_concat_max_len }}
 join_buffer_size = {{ mysql_join_buffer_size }}
-innodb_ft_min_token_size = {{ mysql_innodb_ft_min_token_size }}
-innodb_ft_max_token_size = {{ mysql_innodb_ft_max_token_size }}
 ft_min_word_len = {{ mysql_ft_min_word_len }}
 ft_max_word_len = {{ mysql_ft_max_word_len }}
 


### PR DESCRIPTION
Hi!

This is a very small modification to allow to set a pair of "fulltext" options: min and max characters in a indexed word (https://dev.mysql.com/doc/refman/5.7/en/fulltext-fine-tuning.html)

This Ansible-role is very nice, and with this small modification it will be very usefull for me!

Thank you!