### PR TITLE
Allow symlink for /var/lib/mysql directory.

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -43,6 +43,7 @@
     owner: mysql
     group: mysql
     mode:  0755
+    follow: yes
     setype: mysqld_db_t
 
 - name: Set ownership on slow query log file (if configured).


### PR DESCRIPTION
For cases where the mysql data lives on a different partition or some-such. In my experience, this is not uncommon.