### PR TITLE
[Debian] Infer required Python library from interpreter

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -7,8 +7,12 @@
   apt: update_cache=yes
   when: mysql_installed.stat.exists == false
 
+- name: Determine required MySQL Python libraries.
+  set_fact:
+    deb_mysql_python_package: "{% if 'python3' in ansible_python_interpreter|default('') %}python3-mysqldb{% else %}python-mysqldb{% endif %}"
+
 - name: Ensure MySQL Python libraries are installed.
-  apt: "name=python-mysqldb state=installed"
+  apt: "name={{ deb_mysql_python_package }} state=installed"
 
 - name: Ensure MySQL packages are installed.
   apt: "name={{ item }} state=installed"


### PR DESCRIPTION
When using the Python3 interpreter, Ansible's MySQL module requires `python3-mysql` instead of `python-mysql`.

This tackles the same problem as described in #232, but infers the required library from the python interpreter Ansible is running with instead of relying on the target hosts' shell output.

:octocat: 