### PR TITLE
Support empty sql-mode

### DIFF
--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -14,7 +14,7 @@ pid-file = {{ mysql_pid_file }}
 {% if mysql_skip_name_resolve %}
 skip-name-resolve
 {% endif %}
-{% if mysql_sql_mode %}
+{% if mysql_sql_mode is defined %}
 sql_mode = {{ mysql_sql_mode }}
 {% endif %}
 


### PR DESCRIPTION
The mysql parameter *sql-mode* accepts empty value. So, the role variable mysql_sql_mode should accept it as well.