### PR TITLE
Make the role compatible with MySQL 8

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,4 +1,9 @@
 ---
+- name: Get MySQL version.
+  command: 'mysql --version'
+  register: mysql_cli_version
+  changed_when: false
+
 - name: Copy my.cnf global MySQL configuration.
   template:
     src: my.cnf.j2

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -1,9 +1,4 @@
 ---
-- name: Get MySQL version.
-  command: 'mysql --version'
-  register: mysql_cli_version
-  changed_when: false
-
 - name: Ensure default user is present.
   mysql_user:
     name: "{{ mysql_user_name }}"
@@ -43,7 +38,7 @@
     mysql -u root -NBe
     'ALTER USER "{{ mysql_root_username }}"@"{{ item }}" IDENTIFIED WITH mysql_native_password BY "{{ mysql_root_password }}";'
   with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
-  when: ((mysql_install_packages | bool) or mysql_root_password_update) and ('5.7.' in mysql_cli_version.stdout)
+  when: ((mysql_install_packages | bool) or mysql_root_password_update) and ('5.7.' in mysql_cli_version.stdout or '8.0.' in mysql_cli_version.stdout)
 
 # Set root password for MySQL < 5.7.x.
 - name: Update MySQL root password for localhost root account (< 5.7.x).
@@ -51,7 +46,7 @@
     mysql -NBe
     'SET PASSWORD FOR "{{ mysql_root_username }}"@"{{ item }}" = PASSWORD("{{ mysql_root_password }}");'
   with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
-  when: ((mysql_install_packages | bool) or mysql_root_password_update) and ('5.7.' not in mysql_cli_version.stdout)
+  when: ((mysql_install_packages | bool) or mysql_root_password_update) and ('5.7.' not in mysql_cli_version.stdout and '8.0.' not in mysql_cli_version.stdout)
 
 # Has to be after the root password assignment, for idempotency.
 - name: Copy .my.cnf file with root password credentials.

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -81,9 +81,11 @@ read_buffer_size = {{ mysql_read_buffer_size }}
 read_rnd_buffer_size = {{ mysql_read_rnd_buffer_size }}
 myisam_sort_buffer_size = {{ mysql_myisam_sort_buffer_size }}
 thread_cache_size = {{ mysql_thread_cache_size }}
+{% if '8.0.' not in mysql_cli_version.stdout %}
 query_cache_type = {{ mysql_query_cache_type }}
 query_cache_size = {{ mysql_query_cache_size }}
 query_cache_limit = {{ mysql_query_cache_limit }}
+{% endif %}
 max_connections = {{ mysql_max_connections }}
 tmp_table_size = {{ mysql_tmp_table_size }}
 max_heap_table_size = {{ mysql_max_heap_table_size }}
@@ -96,7 +98,7 @@ lower_case_table_names = {{ mysql_lower_case_table_names }}
 event_scheduler = {{ mysql_event_scheduler_state }}
 
 # InnoDB settings.
-{% if mysql_supports_innodb_large_prefix %}
+{% if mysql_supports_innodb_large_prefix and '8.0.' not in mysql_cli_version.stdout %}
 innodb_large_prefix = {{ mysql_innodb_large_prefix }}
 innodb_file_format = {{ mysql_innodb_file_format }}
 {% endif %}


### PR DESCRIPTION
This role works great, but some configuration doesn't work for MySQL 8. There's a few variables that aren't supported anymore. See https://dev.mysql.com/doc/refman/8.0/en/added-deprecated-removed.html#optvars-removed. I've wrapped those settings around a conditional based on the `mysql_cli_version` fact.

Also I've edited the two tasks that set the root password based on the version so that 8.0 uses the right one.