### PR TITLE
Fix #274: Always register the mysql_cli_version variable

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -3,6 +3,7 @@
   command: 'mysql --version'
   register: mysql_cli_version
   changed_when: false
+  check_mode: no
 
 - name: Copy my.cnf global MySQL configuration.
   template:


### PR DESCRIPTION
This fixes #274 caused by my previous PR #273. Since the `my.cnf.j2` template now uses the `msql_cli_version` var to determine if some settings shouldn't be there, it has to always run in normal mode.

Unfortunately when running this role in check mode on a clean host, this task will fail because the `mysql` binary won't initally be available. However, even before PR #273, this role failed in check mode on a clean host on `Set ownership on error log file` because the file wouldn't exist, so I hope the earlier failure now isn't unexpected.