### PR TITLE
Option to omit pid-file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
     playbook: test.yml
   - distro: ubuntu1404
     playbook: test.yml
+  - distro: centos7
+    playbok: centos-7-mariadb-10-test.yml
 
 script:
   # Configure test script so we can run extra tests after playbook is run.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The formats of these are the same as in the `mysql_user` module.
 
 For some recent versions of MariaDB you might not want to specify `pid-file`. For such situations, set a blank value.
 
-    mysql_pid_file: 
+    mysql_pid_file: ''
 
 Default MySQL connection configuration.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Whether MySQL should be enabled on startup.
 
     mysql_config_file: *default value depends on OS*
     mysql_config_include_dir: *default value depends on OS*
-    
+
 The main my.cnf configuration file and include directory.
 
     overwrite_global_mycnf: yes
@@ -90,6 +90,10 @@ The formats of these are the same as in the `mysql_user` module.
     mysql_socket: *default value depends on OS*
     mysql_pid_file: *default value depends on OS*
 
+For some recent versions of MariaDB you might not want to specify `pid-file`. For such situations, set a blank value.
+
+    mysql_pid_file: 
+
 Default MySQL connection configuration.
 
     mysql_log_file_group: mysql *adm on Debian*
@@ -133,7 +137,7 @@ If you want to install MySQL from the official repository instead of installing 
         name: http://repo.mysql.com/mysql-community-release-el7-5.noarch.rpm
         state: present
       when: ansible_os_family == "RedHat"
-  
+
     - name: Override variables for MySQL (RedHat).
       set_fact:
         mysql_daemon: mysqld

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -10,7 +10,9 @@ port = {{ mysql_port }}
 bind-address = {{ mysql_bind_address }}
 datadir = {{ mysql_datadir }}
 socket = {{ mysql_socket }}
+{% if mysql_pid_file %}
 pid-file = {{ mysql_pid_file }}
+{% endif %}
 {% if mysql_skip_name_resolve %}
 skip-name-resolve
 {% endif %}
@@ -114,7 +116,9 @@ quick
 max_allowed_packet = {{ mysql_mysqldump_max_allowed_packet }}
 
 [mysqld_safe]
+{% if mysql_pid_file %}
 pid-file = {{ mysql_pid_file }}
+{% endif %}
 
 {% if mysql_config_include_files | length %}
 # * IMPORTANT: Additional settings that can override those from this file!

--- a/tests/centos-7-mariadb-10-test.yml
+++ b/tests/centos-7-mariadb-10-test.yml
@@ -1,0 +1,23 @@
+---
+- hosts: all
+  vars:
+    mysql_packages:
+      - mariadb
+      - mariadb-server
+      - mariadb-libs
+      - MySQL-python
+      - perl-DBD-MySQL
+    mysql_log_error: /var/log/mariadb.log
+    mysql_supports_innodb_large_prefix: false
+    mysql_pid_file: 
+  pre_tasks:
+    - name: Configure MariaDB Repository
+      yum_repository:
+        name: mariadb
+        description: MariaDB
+        baseurl: http://yum.mariadb.org/10.3/centos7-amd64
+        gpgkey: https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+        gpgcheck: true
+        state: present
+  roles:
+    - role_under_test

--- a/tests/centos-7-mariadb-10-test.yml
+++ b/tests/centos-7-mariadb-10-test.yml
@@ -9,7 +9,7 @@
       - perl-DBD-MySQL
     mysql_log_error: /var/log/mariadb.log
     mysql_supports_innodb_large_prefix: false
-    mysql_pid_file: 
+    mysql_pid_file: ''
   pre_tasks:
     - name: Configure MariaDB Repository
       yum_repository:


### PR DESCRIPTION
Having pid-file can cause issues in recent versions of MariaDB.