### PR TITLE
Prevent missing getmaster registers from breaking the playbook

### DIFF
--- a/tasks/replication.yml
+++ b/tasks/replication.yml
@@ -37,8 +37,8 @@
     master_host: "{{ mysql_replication_master }}"
     master_user: "{{ mysql_replication_user.name }}"
     master_password: "{{ mysql_replication_user.password }}"
-    master_log_file: "{{ master.File }}"
-    master_log_pos: "{{ master.Position }}"
+    master_log_file: "{{ master.File | default('') }}"
+    master_log_pos: "{{ master.Position | default('')  }}"
   ignore_errors: True
   when: >
     ((slave.Is_Slave is defined and not slave.Is_Slave) or (slave.Is_Slave is not defined and slave is failed))


### PR DESCRIPTION
If the `getmaster` returns no results, currently trying to access `File` and `Position` on those variables breaks the playbook as they're undefined. This adds a default if they don't exist.