### PR TITLE
Setup replication before users/databases

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,6 @@
 # Configure MySQL.
 - include_tasks: configure.yml
 - include_tasks: secure-installation.yml
+- include_tasks: replication.yml
 - include_tasks: databases.yml
 - include_tasks: users.yml
-- include_tasks: replication.yml


### PR DESCRIPTION
When a new install is done the databases and users are created before 
the replication is configured. This way the users an databases are not 
replicted.

This commit moves the replication before user/database creation.