### PR TITLE
Allow modifying the log_bin settings

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -103,6 +103,10 @@ mysql_config_include_files: []
 #  - src: path/relative/to/playbook/file.cnf
 #  - { src: path/relative/to/playbook/anotherfile.cnf, force: yes }
 
+# Set the location/name of the binlog
+mysql_log_bin: "mysql-bin"
+mysql_log_bin_index: "mysql-bin.index"
+
 # Databases.
 mysql_databases: []
 #   - name: example

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -41,8 +41,8 @@ long_query_time = {{ mysql_slow_query_time }}
 server-id = {{ mysql_server_id }}
 
 {% if mysql_replication_role == 'master' %}
-log_bin = mysql-bin
-log-bin-index = mysql-bin.index
+log_bin = {{ mysql_log_bin }}
+log-bin-index = {{ mysql_log_bin_index }}
 expire_logs_days = {{ mysql_expire_logs_days }}
 max_binlog_size = {{ mysql_max_binlog_size }}
 binlog_format = {{mysql_binlog_format}}


### PR DESCRIPTION
This commit allow setting the location and the name of the mysql-bin and 
mysql-bin.index.

This is useful for some installations where you want to have the 
database and logfiles on different media.

If not set, the old defaults are used.