### PR TITLE
allow disalbling pid-file

### DIFF
--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -10,7 +10,9 @@ port = {{ mysql_port }}
 bind-address = {{ mysql_bind_address }}
 datadir = {{ mysql_datadir }}
 socket = {{ mysql_socket }}
+{% if mysql_pid_file %}
 pid-file = {{ mysql_pid_file }}
+{% endif %}
 {% if mysql_skip_name_resolve %}
 skip-name-resolve
 {% endif %}


### PR DESCRIPTION
E.g. for MariaDB rely completely on systemd and don't create pid file.