### PR TITLE
Allows sql mode to be empty

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,7 @@ mysql_port: "3306"
 mysql_bind_address: '0.0.0.0'
 mysql_skip_name_resolve: false
 mysql_datadir: /var/lib/mysql
-mysql_sql_mode: ''
+mysql_sql_mode: 'platform_default'
 # The following variables have a default value depending on operating system.
 # mysql_pid_file: /var/run/mysqld/mysqld.pid
 # mysql_socket: /var/lib/mysql/mysql.sock

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -14,7 +14,7 @@ pid-file = {{ mysql_pid_file }}
 {% if mysql_skip_name_resolve %}
 skip-name-resolve
 {% endif %}
-{% if mysql_sql_mode %}
+{% if mysql_sql_mode != 'platform_default' %}
 sql_mode = {{ mysql_sql_mode }}
 {% endif %}
 


### PR DESCRIPTION
According to the [documentation](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_sql_mode), the default for `sql_mode` is not to be empty. If someone wants to set it to be empty, it is impossible with this role. This PR changes that so that it becomes possible.