### PR TITLE
Percona/mysql 5.7 on CentOS 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible Role: MySQL
 
-[![Build Status](https://travis-ci.org/wouterdt/ansible-role-mysql.svg?branch=master)](https://travis-ci.org/geerlingguy/ansible-role-mysql)
+[![Build Status](https://travis-ci.org/geerlingguy/ansible-role-mysql.svg?branch=master)](https://travis-ci.org/geerlingguy/ansible-role-mysql)
 
 Installs and configures MySQL or MariaDB server on RHEL/CentOS or Debian/Ubuntu servers.
 

--- a/molecule/percona/molecule.yml
+++ b/molecule/percona/molecule.yml
@@ -1,0 +1,30 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  enabled: false
+  options:
+    config-file: molecule/default/yaml-lint.yml
+platforms:
+  - name: instance
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-playbook.yml}
+scenario:
+  name: percona
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/percona/playbook.yml
+++ b/molecule/percona/playbook.yml
@@ -12,7 +12,7 @@
       mysql_packages: Percona-Server-server-57
       mysql_root_password: Root123$  # the role's default password is not accepted by mysql
   roles:
-    - role: ansible-role-mysql
+    - role: geerlingguy.mysql
 
   post_tasks:
     - name: Make sure we can connect to MySQL via Unix socket.

--- a/molecule/percona/playbook.yml
+++ b/molecule/percona/playbook.yml
@@ -1,0 +1,24 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  pre_tasks:
+  - name: "Setup percona repo"
+    yum:
+      name: http://www.percona.com/downloads/percona-release/redhat/0.1-6/percona-release-0.1-6.noarch.rpm
+      state: present
+  - name: set fact for percona binary
+    set_fact:
+      mysql_packages: Percona-Server-server-57
+      mysql_root_password: Root123$  # the role's default password is not accepted by mysql
+  roles:
+    - role: ansible-role-mysql
+
+  post_tasks:
+    - name: Make sure we can connect to MySQL via Unix socket.
+      command: "mysql -u root -p{{mysql_root_password}} -e 'show databases;'"
+      changed_when: false
+
+    - name: Make sure we can connect to MySQL via TCP.
+      command: "mysql -u root -p{{mysql_root_password}} -h 127.0.0.1 -e 'show databases;'"
+      changed_when: false

--- a/molecule/percona/yaml-lint.yml
+++ b/molecule/percona/yaml-lint.yml
@@ -1,0 +1,6 @@
+---
+extends: default
+rules:
+  line-length:
+    max: 160
+    level: warning

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -1,4 +1,106 @@
 ---
+
+- name: Get Mysql version
+  shell: mysqladmin --version | grep -o -P '(?<=Distrib).*(?=,)'
+  register: mysql_version
+  changed_when: false
+
+- name: Get Mysql version
+  shell: mysqladmin --version
+  register: mysql_type
+  changed_when: false
+
+- name: Check if installation is MariaDB
+  when: '"MariaDB" not in mysql_type.stdout'
+  set_fact: is_mariadb=false
+
+- name: Check if installation is MariaDB
+  when: '"MariaDB" in mysql_type.stdout'
+  set_fact: is_mariadb=true
+# https://www.percona.com/blog/2016/05/18/where-is-the-mysql-5-7-root-password/
+# mysql 5.7 has changd it's default password behaviour and it's different on RH
+# an expired password is echoed in the logs upon installation instead of an empty one
+- block:
+  - name: check if the root password has already been set
+    stat:
+      path: "{{ mysql_root_home }}/.my.cnf"
+    register: root_my_stat
+
+  - name: Get the temporary password from the install logs when not Mariadb and version is > 5.6
+    shell: "cat {{mysql_log_error}} | grep 'A temporary password is generated for' | tail -1 | sed -n 's/.*root@localhost: //p'"
+    register: mysql_temp_pwd
+    when: root_my_stat['stat'].exists == false
+  # refresh the temp root password so we can use mysql_user to set it...
+  - name: Set new password from temporary password
+    shell: 'mysql -e
+      "SET PASSWORD = PASSWORD(''{{ mysql_temp_pwd.stdout }}'');" --connect-expired-password -u{{mysql_root_username}}
+      -p"{{ mysql_temp_pwd.stdout }}"'
+    when: root_my_stat['stat'].exists == false
+  - name: Set permanent root password  # first install using the temp password
+    mysql_user:
+      login_user: root
+      login_password: "{{ mysql_temp_pwd.stdout }}"
+      name: root
+      password: "{{mysql_root_password}}"
+    when: root_my_stat['stat'].exists == false
+  - name: Set permanent root password  # if an update is required read the old root password rom the mysql config file and set it
+    mysql_user:
+      name: root
+      password: "{{mysql_root_password}}"
+    when: mysql_root_password_update
+  when: is_mariadb!=true and mysql_version is version('5.6','>') and ansible_os_family == 'RedHat'
+
+- block:
+    - name: Get list of hosts for the root user.
+      command: mysql -NBe
+        "SELECT Host
+        FROM mysql.user
+        WHERE User = '{{ mysql_root_username }}'
+        ORDER BY (Host='localhost') ASC"
+      register: mysql_root_hosts
+      changed_when: false
+      check_mode: false
+      when: mysql_install_packages | bool or mysql_root_password_update
+    # Note: We do not use mysql_user for this operation, as it doesn't always update
+    # the root password correctly. See: https://goo.gl/MSOejW
+    # Set root password for MySQL >= 5.7.x.
+    - name: Update MySQL root password for localhost root account (5.7.x).
+      shell: >
+        mysql -u root -NBe
+        'ALTER USER "{{ mysql_root_username }}"@"{{ item }}"
+        IDENTIFIED WITH mysql_native_password BY "{{ mysql_root_password }}";'
+      with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
+      when: >
+        ((mysql_install_packages | bool) or mysql_root_password_update)
+        and ('5.7.' in mysql_cli_version.stdout or '8.0.' in mysql_cli_version.stdout) and ansible_os_family != 'RedHat'
+
+    # Set root password for MySQL < 5.7.x.
+    - name: Update MySQL root password for localhost root account (< 5.7.x).
+      shell: >
+        mysql -NBe
+        'SET PASSWORD FOR "{{ mysql_root_username }}"@"{{ item }}" = PASSWORD("{{ mysql_root_password }}");'
+      with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
+      when: >
+        ((mysql_install_packages | bool) or mysql_root_password_update)
+        and ('5.7.' not in mysql_cli_version.stdout and '8.0.' not in mysql_cli_version.stdout)
+  when: is_mariadb==true or ansible_os_family != 'RedHat'
+
+# Has to be after the root password assignment, for idempotency.
+- name: Copy .my.cnf file with root password credentials.
+  template:
+    src: "root-my.cnf.j2"
+    dest: "{{ mysql_root_home }}/.my.cnf"
+    owner: root
+    group: root
+    mode: 0600
+  when: mysql_install_packages | bool or mysql_root_password_update
+
+- name: Disallow root login remotely
+  command: 'mysql -NBe "{{ item }}"'
+  with_items:
+    - DELETE FROM mysql.user WHERE User='{{ mysql_root_username }}' AND Host NOT IN ('localhost', '127.0.0.1', '::1')
+  changed_when: false
+
 - name: Ensure default user is present.
   mysql_user:
     name: "{{ mysql_user_name }}"
@@ -7,6 +109,7 @@
     priv: '*.*:ALL,GRANT'
     state: present
   when: mysql_user_name != mysql_root_username
+
 
 # Has to be after the password assignment, for idempotency.
 - name: Copy user-my.cnf file with password credentials.
@@ -19,55 +122,6 @@
     mysql_user_name != mysql_root_username
     and (mysql_install_packages | bool or mysql_user_password_update)
 
-- name: Disallow root login remotely
-  command: 'mysql -NBe "{{ item }}"'
-  with_items:
-    - DELETE FROM mysql.user WHERE User='{{ mysql_root_username }}' AND Host NOT IN ('localhost', '127.0.0.1', '::1')
-  changed_when: false
-
-- name: Get list of hosts for the root user.
-  command: mysql -NBe
-    "SELECT Host
-    FROM mysql.user
-    WHERE User = '{{ mysql_root_username }}'
-    ORDER BY (Host='localhost') ASC"
-  register: mysql_root_hosts
-  changed_when: false
-  check_mode: false
-  when: mysql_install_packages | bool or mysql_root_password_update
-
-# Note: We do not use mysql_user for this operation, as it doesn't always update
-# the root password correctly. See: https://goo.gl/MSOejW
-# Set root password for MySQL >= 5.7.x.
-- name: Update MySQL root password for localhost root account (5.7.x).
-  shell: >
-    mysql -u root -NBe
-    'ALTER USER "{{ mysql_root_username }}"@"{{ item }}"
-    IDENTIFIED WITH mysql_native_password BY "{{ mysql_root_password }}";'
-  with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
-  when: >
-    ((mysql_install_packages | bool) or mysql_root_password_update)
-    and ('5.7.' in mysql_cli_version.stdout or '8.0.' in mysql_cli_version.stdout)
-
-# Set root password for MySQL < 5.7.x.
-- name: Update MySQL root password for localhost root account (< 5.7.x).
-  shell: >
-    mysql -NBe
-    'SET PASSWORD FOR "{{ mysql_root_username }}"@"{{ item }}" = PASSWORD("{{ mysql_root_password }}");'
-  with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
-  when: >
-    ((mysql_install_packages | bool) or mysql_root_password_update)
-    and ('5.7.' not in mysql_cli_version.stdout and '8.0.' not in mysql_cli_version.stdout)
-
-# Has to be after the root password assignment, for idempotency.
-- name: Copy .my.cnf file with root password credentials.
-  template:
-    src: "root-my.cnf.j2"
-    dest: "{{ mysql_root_home }}/.my.cnf"
-    owner: root
-    group: root
-    mode: 0600
-  when: mysql_install_packages | bool or mysql_root_password_update
 
 - name: Get list of hosts for the anonymous user.
   command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = ""'

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -50,7 +50,7 @@
     when: mysql_root_password_update
   when: >
    is_mariadb != true and
-   ( mysql_version.stdout is version('5.6','>')) and
+   ( mysql_version.stdout is version('5.7','>=')) and
    (ansible_os_family == 'RedHat' and  ansible_distribution_major_version is version('7','>='))
 
 - block:

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Get Mysql version
-  shell: mysqladmin --version | grep -o -P '(?<=Distrib).*(?=,)'
+  shell: mysqladmin --version | grep -o -P '(?<=Distrib ).*(?=,)'
   register: mysql_version
   changed_when: false
 
@@ -48,7 +48,14 @@
       name: root
       password: "{{mysql_root_password}}"
     when: mysql_root_password_update
-  when: is_mariadb!=true and mysql_version is version('5.6','>') and (ansible_os_family == 'RedHat' and  ansible_distribution_major_version >= 7)
+  when: >
+   is_mariadb != true and
+   ( mysql_version.stdout is version('5.6','>')) and
+   (ansible_os_family == 'RedHat' and  ansible_distribution_major_version is version('7','>='))
+- debug:
+    var: ansible_os_family
+- debug:
+    var: ansible_distribution_major_version
 - block:
     - name: Get list of hosts for the root user.
       command: mysql -NBe
@@ -82,7 +89,7 @@
       when: >
         ((mysql_install_packages | bool) or mysql_root_password_update)
         and ('5.7.' not in mysql_cli_version.stdout and '8.0.' not in mysql_cli_version.stdout)
-  when: is_mariadb==true or (ansible_os_family != 'RedHat' or( ansible_os_family == 'RedHat' and ansible_distribution_major_version <= 6))
+  when: ( ansible_os_family == 'RedHat' and (ansible_distribution_major_version is version('6','<=') or is_mariadb == true )) or ansible_os_family != 'RedHat'
 
 # Has to be after the root password assignment, for idempotency.
 - name: Copy .my.cnf file with root password credentials.

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -48,8 +48,7 @@
       name: root
       password: "{{mysql_root_password}}"
     when: mysql_root_password_update
-  when: is_mariadb!=true and mysql_version is version('5.6','>') and ansible_os_family == 'RedHat'
-
+  when: is_mariadb!=true and mysql_version is version('5.6','>') and (ansible_os_family == 'RedHat' and  ansible_distribution_major_version >= 7)
 - block:
     - name: Get list of hosts for the root user.
       command: mysql -NBe
@@ -83,7 +82,7 @@
       when: >
         ((mysql_install_packages | bool) or mysql_root_password_update)
         and ('5.7.' not in mysql_cli_version.stdout and '8.0.' not in mysql_cli_version.stdout)
-  when: is_mariadb==true or ansible_os_family != 'RedHat'
+  when: is_mariadb==true or (ansible_os_family != 'RedHat' or( ansible_os_family == 'RedHat' and ansible_distribution_major_version <= 6))
 
 # Has to be after the root password assignment, for idempotency.
 - name: Copy .my.cnf file with root password credentials.

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -52,10 +52,7 @@
    is_mariadb != true and
    ( mysql_version.stdout is version('5.6','>')) and
    (ansible_os_family == 'RedHat' and  ansible_distribution_major_version is version('7','>='))
-- debug:
-    var: ansible_os_family
-- debug:
-    var: ansible_distribution_major_version
+
 - block:
     - name: Get list of hosts for the root user.
       command: mysql -NBe

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -10,7 +10,15 @@
 
 - name: Include OS-specific variables (RedHat).
   include_vars: "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == 6
+
+- name: Include OS-specific variables (RedHat).
+  include_vars: "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version > 6 and (mysql_packages is not defined or "Percona" not in mysql_packages)
+
+- name: Include OS-specific variables (RedHat) for a Percona Install.  # use the mysql variables from RH6 for a percona install on RH7
+  include_vars: "{{ ansible_os_family }}-6.yml"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version > 6 and (mysql_packages is defined and "Percona" in mysql_packages)
 
 - name: Define mysql_packages.
   set_fact:


### PR DESCRIPTION
Added the possibility to handle the installation of a Mysql/Percona Server 5.7 on CentOS 7.
On Percona & Mysql on Centos the default password handling is completely different than on the MariaDB  (https://www.percona.com/blog/2016/05/18/where-is-the-mysql-5-7-root-password/) This required some splitting and  moving around in secure_installation.yml.
Added a molecule scenario to test setting up the Percona server.
This version still would require you to set the mysql_packages as I did not add the Percona yum repositories to the role.
