### PR TITLE
#165: Preserve datadir contents on change.

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,19 +1,21 @@
 ---
-- name: Pull down the existing config file for parsing.
-  fetch:
-    src: /etc/my.cnf
-    dest: /tmp/geerlingguy.mysql
-  ignore_errors: true
-
-- name: Get the existing data directory.
-  set_fact:
-    mysql_original_datadir: "{{ lookup('ini', 'datadir section=mysqld file=/tmp/geerlingguy.mysql/{{ inventory_hostname }}/etc/my.cnf', errors='ignore') | default('/var/lib/mysql', true) }}"
-
 - name: Get MySQL version.
   command: 'mysql --version'
   register: mysql_cli_version
   changed_when: false
   check_mode: false
+
+- name: Pull down the existing config file for parsing.
+  fetch:
+    src: /etc/my.cnf
+    dest: /tmp/geerlingguy.mysql
+  ignore_errors: true
+  changed_when: false
+  check_mode: false
+
+- name: Get the existing data directory.
+  set_fact:
+    mysql_original_datadir: "{{ lookup('ini', 'datadir section=mysqld file=/tmp/geerlingguy.mysql/{{ inventory_hostname }}/etc/my.cnf', errors='ignore') | default('/var/lib/mysql', true) }}"
 
 - name: Copy my.cnf global MySQL configuration.
   template:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -5,17 +5,12 @@
   changed_when: false
   check_mode: false
 
-- name: Pull down the existing config file for parsing.
-  fetch:
-    src: /etc/my.cnf
-    dest: /tmp/geerlingguy.mysql
+- name: Get the existing data directory.
+  register: mysql_original_datadir
+  shell: grep datadir /etc/my.cnf | cut -f2 -d"="
   ignore_errors: true
   changed_when: false
   check_mode: false
-
-- name: Get the existing data directory.
-  set_fact:
-    mysql_original_datadir: "{{ lookup('ini', 'datadir section=mysqld file=/tmp/geerlingguy.mysql/{{ inventory_hostname }}/etc/my.cnf', errors='ignore') | default('/var/lib/mysql', true) }}"
 
 - name: Copy my.cnf global MySQL configuration.
   template:
@@ -56,14 +51,14 @@
 
 - name: Copy the data from installation into place.
   synchronize:
-    src: "{{ mysql_original_datadir }}/"
+    src: "{{ mysql_original_datadir.stdout | trim }}/"
     dest: "{{ mysql_datadir }}"
     archive: true
     compress: false
     rsync_opts:
       - "-AX"
   delegate_to: "{{ inventory_hostname }}"
-  when: mysql_original_datadir != mysql_datadir
+  when: mysql_original_datadir.stdout | trim != mysql_datadir
 
 - name: Set ownership on slow query log file (if configured).
   file:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -56,8 +56,8 @@
   synchronize:
     src: "{{ mysql_original_datadir }}/"
     dest: "{{ mysql_datadir }}"
-    archive: yes
-    compress: no
+    archive: true
+    compress: false
     rsync_opts:
       - "-AX"
   delegate_to: "{{ inventory_hostname }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,4 +1,14 @@
 ---
+- name: Pull down the existing config file for parsing.
+  fetch:
+    src: /etc/my.cnf
+    dest: /tmp/geerlingguy.mysql
+  ignore_errors: true
+
+- name: Get the existing data directory.
+  set_fact:
+    mysql_original_datadir: "{{ lookup('ini', 'datadir section=mysqld file=/tmp/geerlingguy.mysql/{{ inventory_hostname }}/etc/my.cnf', errors='ignore') | default('/var/lib/mysql', true) }}"
+
 - name: Get MySQL version.
   command: 'mysql --version'
   register: mysql_cli_version
@@ -42,14 +52,16 @@
     warn: false
   when: mysql_slow_query_log_enabled
 
-- name: Create datadir if it does not exist
-  file:
-    path: "{{ mysql_datadir }}"
-    state: directory
-    owner: mysql
-    group: mysql
-    mode: 0755
-    setype: mysqld_db_t
+- name: Copy the data from installation into place.
+  synchronize:
+    src: "{{ mysql_original_datadir }}/"
+    dest: "{{ mysql_datadir }}"
+    archive: yes
+    compress: no
+    rsync_opts:
+      - "-AX"
+  delegate_to: "{{ inventory_hostname }}"
+  when: mysql_original_datadir != mysql_datadir
 
 - name: Set ownership on slow query log file (if configured).
   file:

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -110,7 +110,6 @@ innodb_flush_log_at_trx_commit = {{ mysql_innodb_flush_log_at_trx_commit }}
 innodb_lock_wait_timeout = {{ mysql_innodb_lock_wait_timeout }}
 
 [mysqldump]
-quick
 max_allowed_packet = {{ mysql_mysqldump_max_allowed_packet }}
 
 [mysqld_safe]


### PR DESCRIPTION
This PR preserves the contents of the MySQL datadir when it is changed. This is helpfully generally, but specifically for #165 where newer versions of MariaDB create required data as part of the install, resulting in failure to start the service on initial install.

`quick` has been removed from the `my.cnf.j2` as `lookup('ini')` can't handle no value options and `--quick` is [enabled by default](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html):
> To dump tables row by row, use the --quick option (or --opt, which enables --quick). The --opt option (and hence --quick) is enabled by default, so to enable memory buffering, use --skip-quick.