### PR TITLE
Avoid using a loop with the Apt module, because it is deprecated

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -12,10 +12,14 @@
     deb_mysql_python_package: "{% if 'python3' in ansible_python_interpreter|default('') %}python3-mysqldb{% else %}python-mysqldb{% endif %}"
 
 - name: Ensure MySQL Python libraries are installed.
-  apt: "name={{ deb_mysql_python_package }} state=present"
+  apt:
+    name: "{{ deb_mysql_python_package }}"
+    state: present
 
 - name: Ensure MySQL packages are installed.
-  apt: "name={{ mysql_packages }} state=present"
+  apt:
+    name: "{{ mysql_packages }}"
+    state: present
   register: deb_mysql_install_packages
 
 # Because Ubuntu starts MySQL as part of the install process, we need to stop


### PR DESCRIPTION
Fixes the following deprecation warning on Debian-based hosts:

```ansible
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: {{ item }}`, please use `name: u'{{ mysql_packages 
}}'` and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```