### PR TITLE
Add `update_password` option to user config

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The MySQL users and their privileges. A user has the values:
   - `name`
   - `host` (defaults to `localhost`)
   - `password` (can be plaintext or encrypted—if encrypted, set `encrypted: yes`)
+  - `update_password`  (default `always`, to only set password on user creation set `update_password: on_create`)
   - `encrypted` (defaults to `no`)
   - `priv` (defaults to `*.*:USAGE`)
   - `append_privs` (defaults to `no`)

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -8,5 +8,6 @@
     state: "{{ item.state | default('present') }}"
     append_privs: "{{ item.append_privs | default('no') }}"
     encrypted: "{{ item.encrypted | default('no') }}"
+    update_password: "{{ item.update_password | default('always') }}"
   with_items: "{{ mysql_users }}"
   no_log: true


### PR DESCRIPTION
I would like to use Ansible to set up initial user configuration, and manage some configuration after the fact.  But if a user chooses to change their MySQL password, I would like for Ansible to not mess with that.  Ansible 2.0 comes with the `update_password` parameter on `mysql_user` and I find it useful to expose this in the user variables.

Default behavior is left as `always` so existing configurations should not break, but with this you have the option to set it to `on_create` which only sets the password on user creation.