### PR TITLE
Allow to skip pid file creation on moder disto and example for latest MariaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,28 @@ If you want to install MySQL from the official repository instead of installing 
 
 This role works with either MySQL or a compatible version of MariaDB. On RHEL/CentOS 7+, the mariadb database engine was substituted as the default MySQL replacement package. No modifications are necessary though all of the variables still reference 'mysql' instead of mariadb.
 
+### Later versions of MariaDB on CentOS 7
+
+If you want to install MariaDB from the official repository instead of installing the system default MariaDB equivalents, you need add repository (see https://downloads.mariadb.org/mariadb/repositories/) and define variabled
+
+```yaml
+  pre_tasks:
+    - name: Install the MariaDB repo.
+    ..
+  
+    - name: Override variables for MariaDB (RedHat).
+      set_fact:
+        mysql_packages:
+          - MariaDB-server
+          - MariaDB-backup
+          - MariaDB-client
+          - MySQL-python
+          - perl-DBD-MySQL
+        mysql_log_error: /var/log/mysqld.err
+        mysql_pid_file:
+      when: ansible_os_family == "RedHat"
+```
+
 #### Ubuntu 14.04 and 16.04 MariaDB configuration
 
 On Ubuntu, the package names are named differently, so the `mysql_package` variable needs to be altered. Set the following variables (at a minimum):

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ This role works with either MySQL or a compatible version of MariaDB. On RHEL/Ce
 
 ### Later versions of MariaDB on CentOS 7
 
-If you want to install MariaDB from the official repository instead of installing the system default MariaDB equivalents, you need add repository (see https://downloads.mariadb.org/mariadb/repositories/) and define variabled
+If you want to install MariaDB from the official repository instead of installing the system default MariaDB equivalents, you need add repository (see https://downloads.mariadb.org/mariadb/repositories/) and define variables
 
 ```yaml
   pre_tasks:

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -10,7 +10,9 @@ port = {{ mysql_port }}
 bind-address = {{ mysql_bind_address }}
 datadir = {{ mysql_datadir }}
 socket = {{ mysql_socket }}
+{% if mysql_pid_file %}
 pid-file = {{ mysql_pid_file }}
+{% endif %}
 {% if mysql_skip_name_resolve %}
 skip-name-resolve
 {% endif %}


### PR DESCRIPTION
Allow to skip pid file creation on moder disto (systemd do not need it if service not fork type)