### PR TITLE
Update my.cnf.j2 : ability to configure a read-write slave

### DIFF
--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -57,7 +57,9 @@ binlog_ignore_db = {{ db.name }}
 {% endif %}
 
 {% if mysql_replication_role == 'slave' %}
+{% if mysql_slave_ro|default(1) %}
 read_only
+{% endif %}
 relay-log = relay-bin
 relay-log-index = relay-bin.index
 {% endif %}


### PR DESCRIPTION
Add a var mysql_slave_ro so that you can change default behavior of the slave being read-only. If you set this var to false the slave will be "read-write" which can be useful in some architectures.