### PR TITLE
Add var mysql_slave_ro to add ability to configure a rw slave

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -124,5 +124,6 @@ mysql_binlog_format: "ROW"
 mysql_expire_logs_days: "10"
 mysql_replication_role: ''
 mysql_replication_master: ''
+#mysql_slave_ro: (default 1 for read-only, 0 for read-write) 
 # Same keys as `mysql_users` above.
 mysql_replication_user: []

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -57,7 +57,9 @@ binlog_ignore_db = {{ db.name }}
 {% endif %}
 
 {% if mysql_replication_role == 'slave' %}
+{% if mysql_slave_ro|default(1) %}
 read_only
+{% endif %}
 relay-log = relay-bin
 relay-log-index = relay-bin.index
 {% endif %}


### PR DESCRIPTION
I needed to have a read-write slave for high availability reasons. I added the variable msyql_slave_ro in the default/main.yml file and a small modification in the template/my.cnf.j2 file so that you can have a rw slave if you set the var to 0 or false. 