### PR TITLE
Fixed ansible_managed comment in .cnf configs

### DIFF
--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 [client]
 #password = your_password

--- a/templates/root-my.cnf.j2
+++ b/templates/root-my.cnf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 [client]
 user="{{ mysql_root_username }}"

--- a/templates/user-my.cnf.j2
+++ b/templates/user-my.cnf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 [client]
 user="{{ mysql_user_name }}"


### PR DESCRIPTION
In case ansible_managed is a multiline string, role produces malformed configs.
ansible.cfg:
```
ansible_managed =
    This file is managed by ansible.
    Don't make changes here - they will be overwritten.
```
resultant config:
```
$ head /etc/my.cnf
#
This file is managed by ansible.
Don't make changes here - they will be overwritten.
...
```
with fix applied:
```
$ head /etc/my.cnf
#
#
# This file is managed by ansible.
# Don't make changes here - they will be overwritten.
#
```
