### PR TITLE
Fix [DEPRECATION WARNING] on Include OS-specific variables (causing A…

### DIFF
--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -6,7 +6,7 @@
     - files:
         - "vars/{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
         - "vars/{{ ansible_os_family }}.yml"
-      skip: true
+      default: ""
 
 - name: Define mysql_packages.
   set_fact:


### PR DESCRIPTION
`with_first_found` combined with `skip: true` seems to cause a deprecation warning in `/tasks/variables.ym`l file.
This issue leads to pipeline fail in Azur Devops.

Fixed by fixing `default: ""`