### PR TITLE
Add mysql_enable_config_include_dir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Whether the global my.cnf should be overwritten each time this role is run. Sett
 
 A list of files that should override the default global my.cnf. Each item in the array requires a "src" parameter which is a path to a file. An optional "force" parameter can force the file to be updated each time ansible runs.
 
+    mysql_enable_config_include_dir: false
+
+Whether `mysql_config_include_dir` should always be included in `mysql_config_file` even when `mysql_config_include_files` is empty.
+
     mysql_databases: []
 
 The MySQL databases to create. A database has the values `name`, `encoding` (defaults to `utf8`), `collation` (defaults to `utf8_general_ci`) and `replicate` (defaults to `1`, only used if replication is configured). The formats of these are the same as in the `mysql_db` module.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -103,6 +103,9 @@ mysql_config_include_files: []
 #  - src: path/relative/to/playbook/file.cnf
 #  - { src: path/relative/to/playbook/anotherfile.cnf, force: yes }
 
+# Include mysql_config_include_dir even when mysql_config_include_files is empty
+mysql_enable_config_include_dir: false
+
 # Databases.
 mysql_databases: []
 #   - name: example

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -116,7 +116,7 @@ max_allowed_packet = {{ mysql_mysqldump_max_allowed_packet }}
 [mysqld_safe]
 pid-file = {{ mysql_pid_file }}
 
-{% if mysql_config_include_files | length %}
+{% if mysql_config_include_files | length or mysql_enable_config_include_dir %}
 # * IMPORTANT: Additional settings that can override those from this file!
 #   The files must end with '.cnf', otherwise they'll be ignored.
 #


### PR DESCRIPTION
Previous behavior only includes the `mysql_config_include_dir` in `mysql_config_file` when `mysql_config_include_files` is not empty. This option (when set to true) will always include the `mysql_config_include_dir`.

This is useful for environments where users may have configuration in `/etc/my.cnf.d/` that needs to be enabled, but is not managed by ansible or may be managed elsewhere.

In my opinion `mysql_config_include_dir` should *always* be included regardless of the length of `mysql_config_include_files`, but this PR takes a softer approach in hopes of getting this merged.