### PR TITLE
wip-CLD-766 Add unix socket to root config file

### DIFF
--- a/templates/root-my.cnf.j2
+++ b/templates/root-my.cnf.j2
@@ -3,3 +3,4 @@
 [client]
 user="{{ mysql_root_username }}"
 password="{{ mysql_root_password }}"
+socket="{{ mysql_socket }}"


### PR DESCRIPTION
**Summary**

Fix errors caused by playbook unable to connect as root user to MariaDB by using unix socket connection instead.

**Tests**