### PR TITLE
Adjust Debian 10 specific settings to the proper values used by the Debian package

### DIFF
--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -6,8 +6,8 @@ mysql_log_file_group: adm
 __mysql_slow_query_log_file: /var/log/mysql/mysql-slow.log
 __mysql_log_error: /var/log/mysql/mysql.log
 __mysql_syslog_tag: mariadb
-__mysql_pid_file: /var/run/mysql/mysql.pid
-__mysql_config_file: /etc/my.cnf
-__mysql_config_include_dir: /etc/my.cnf.d
-__mysql_socket: /var/lib/mysql/mysql.sock
+__mysql_pid_file: /run/mysqld/mysqld.pid
+__mysql_config_file: /etc/mysql/my.cnf
+__mysql_config_include_dir: /etc/mysql/conf.d
+__mysql_socket: /run/mysqld/mysqld.sock
 __mysql_supports_innodb_large_prefix: true


### PR DESCRIPTION
This aligns the configuration location with the generic Debian variables
file and uses /run instead of /var/run as the latter is the symlink to
the former.