### PR TITLE
Change force to default(omit)

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -31,7 +31,7 @@
     owner: root
     group: root
     mode: 0644
-    force: "{{ item.force | default(False) }}"
+    force: "{{ item.force | default(omit) }}"
   with_items: "{{ mysql_config_include_files }}"
   notify: restart mysql
 


### PR DESCRIPTION
The role was not identifying changes when the files specified to be placed in the include directories changed.  The issue was that when a file was not declared to to force the file every run it would default to False which would cause the change to not be picked up.  Changed the force option to default(omit) to fix this issue.

Fixes #292