### PR TITLE
Fix issues with pymysql module when using Python3 and defined mysql_socket

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,2 +1,15 @@
+# https://docs.ansible.com/ansible-lint/rules/default_rules.html
+use_default_rules: true
 skip_list:
-  - '204'
+  - '106' # Role name wordpress.deploy does not match ``^[a-z][a-z0-9_]+$`` pattern
+  - '204' # Lines should be no longer than 160 chars
+  - '201' # Trailing whitespace
+  - '301' # Commands should not change things if nothing needs doing
+  - '303' # Using command rather than module
+  - '305' # Use shell only when shell functionality is required
+  - '501' # become_user requires become to work as expected
+  - '701' # meta/main.yml should contain relevant info
+verbosity: 1
+exclude_paths: 
+  - ../.ansible/roles
+  - ../../.ansible/roles

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -32,7 +32,7 @@
     group: root
     mode: 0644
     force: "{{ item.force | default(False) }}"
-  with_items: "{{ mysql_config_include_files }}"
+  loop: "{{ mysql_config_include_files }}"
   notify: restart mysql
 
 - name: Create slow query log file (if configured).
@@ -83,5 +83,8 @@
   tags: ['skip_ansible_galaxy']
 
 - name: Ensure MySQL is started and enabled on boot.
-  service: "name={{ mysql_daemon }} state=started enabled={{ mysql_enabled_on_startup }}"
+  service: 
+    name: "{{ mysql_daemon }}" 
+    state: started 
+    enabled: "{{ mysql_enabled_on_startup }}"
   register: mysql_service_configuration

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -83,8 +83,8 @@
   tags: ['skip_ansible_galaxy']
 
 - name: Ensure MySQL is started and enabled on boot.
-  service: 
-    name: "{{ mysql_daemon }}" 
-    state: started 
+  service:
+    name: "{{ mysql_daemon }}"
+    state: started
     enabled: "{{ mysql_enabled_on_startup }}"
   register: mysql_service_configuration

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -5,4 +5,4 @@
     collation: "{{ item.collation | default('utf8_general_ci') }}"
     encoding: "{{ item.encoding | default('utf8') }}"
     state: "{{ item.state | default('present') }}"
-  with_items: "{{ mysql_databases }}"
+  loop: "{{ mysql_databases }}"

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -83,7 +83,7 @@
   with_items: "{{ mysql_anonymous_hosts.stdout_lines|default([]) }}"
 
 - name: Remove MySQL test database.
-  mysql_db: 
-    name: test 
+  mysql_db:
+    name: test
     state: absent
     login_unix_socket: "{{ mysql_socket }}"

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -83,4 +83,7 @@
   with_items: "{{ mysql_anonymous_hosts.stdout_lines|default([]) }}"
 
 - name: Remove MySQL test database.
-  mysql_db: "name='test' state=absent"
+  mysql_db: 
+    name: test 
+    state: absent
+    login_unix_socket: "{{ mysql_socket }}"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,6 +1,7 @@
 ---
 - name: Check if MySQL is already installed.
-  stat: path=/etc/init.d/mysql
+  stat: 
+    path: /etc/init.d/mysql
   register: mysql_installed
 
 - name: Update apt cache if MySQL is not yet installed.

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check if MySQL is already installed.
-  stat: 
+  stat:
     path: /etc/init.d/mysql
   register: mysql_installed
 

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -10,4 +10,3 @@
     append_privs: "{{ item.append_privs | default('no') }}"
     encrypted: "{{ item.encrypted | default('no') }}"
   loop: "{{ mysql_users }}"
-  no_log: true

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure MySQL users are present.
-  mysql_user:
+  community.mysql.mysql_user:
     login_unix_socket: "{{ mysql_socket }}"
     name: "{{ item.name }}"
     host: "{{ item.host | default('localhost') }}"
@@ -9,5 +9,5 @@
     state: "{{ item.state | default('present') }}"
     append_privs: "{{ item.append_privs | default('no') }}"
     encrypted: "{{ item.encrypted | default('no') }}"
-  with_items: "{{ mysql_users }}"
+  loop: "{{ mysql_users }}"
   no_log: true

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,6 +1,7 @@
 ---
 - name: Ensure MySQL users are present.
   mysql_user:
+    login_unix_socket: "{{ mysql_socket }}"
     name: "{{ item.name }}"
     host: "{{ item.host | default('localhost') }}"
     password: "{{ item.password }}"


### PR DESCRIPTION
Greetings,

I've encountered the following problem against many fresh install scenarios on Debian buster :

```
TASK [geerlingguy.mysql : Remove MySQL test database.] **********************************************************************task path: /home/vagrant/.ansible/roles/geerlingguy.mysql/tasks/secure-installation.yml:85
Monday 15 June 2020  15:06:37 +0000 (0:00:00.039)       0:01:03.780 ***********
Using module file /usr/local/lib/python3.8/dist-packages/ansible/modules/database/mysql/mysql_db.py
Pipelining is enabled.
<192.168.10.21> ESTABLISH SSH CONNECTION FOR USER: ansible
<192.168.10.21> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o 'IdentityFile="/home/vagrant/.ssh/id_rsa"' -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="ansible"' -o ConnectTimeout=30 -o ControlPath=/home/vagrant/.ansible/cp/0139b0c611 192.168.10.21 '/bin/sh -c '"'"'sudo -H -S -n  -u root /bin/sh -c '"'"'"'"'"'"'"'"'echo BECOME-SUCCESS-qmwydjobbvtiackfhboqqivbpdgxssdg ; /usr/bin/python3'"'"'"'"'"'"'"'"' && sleep 0'"'"''
Escalation succeeded
<192.168.10.21> (1, b'\n{"msg": "unable to connect to database, check login_user and login_password are correct or /root/.my.cnf has the credentials. Exception message: Packet sequence number wrong - got 1 expected 0", "failed": true, "exception": "  File \\"/tmp/ansible_mysql_db_payload_x2c8nmx1/ansible_mysql_db_payload.zip/ansible/modules/database/mysql/mysql_db.py\\", line 383, in main\\n  File \\"/tmp/ansible_mysql_db_payload_x2c8nmx1/ansible_mysql_db_payload.zip/ansible/module_utils/mysql.py\\", line 81, in mysql_connect\\n    db_connection = mysql_driver.connect(**config)\\n  File \\"/usr/local/lib/python3.7/dist-packages/pymysql/__init__.py\\", line 94, in Connect\\n    return Connection(*args, **kwargs)\\n  File \\"/usr/local/lib/python3.7/dist-packages/pymysql/connections.py\\", line 325, in __init__\\n    self.connect()\\n  File \\"/usr/local/lib/python3.7/dist-packages/pymysql/connections.py\\", line 598, in connect\\n    self._get_server_information()\\n  File \\"/usr/local/lib/python3.7/dist-packages/pymysql/connections.py\\", line 975, in _get_server_information\\n    packet = self._read_packet()\\n  File \\"/usr/local/lib/python3.7/dist-packages/pymysql/connections.py\\", line 671, in _read_packet\\n    % (packet_number, self._next_seq_id))\\n", "invocation": {"module_args": {"name": ["test"], "state": "absent", "login_host": "localhost", "login_port": 3306, "encoding": "", "collation": "", "connect_timeout": 30, "config_file": "/root/.my.cnf", "single_transaction": false, "quick": true, "ignore_tables": [], "login_user": null, "login_password": null, "login_unix_socket": null, "target": null, "client_cert": null, "client_key": null, "ca_cert": null}}}\n', b'')
<192.168.10.21> Failed to connect to the host via ssh:
The full traceback is:
  File "/tmp/ansible_mysql_db_payload_x2c8nmx1/ansible_mysql_db_payload.zip/ansible/modules/database/mysql/mysql_db.py", line 383, in main
  File "/tmp/ansible_mysql_db_payload_x2c8nmx1/ansible_mysql_db_payload.zip/ansible/module_utils/mysql.py", line 81, in mysql_connect
    db_connection = mysql_driver.connect(**config)
  File "/usr/local/lib/python3.7/dist-packages/pymysql/__init__.py", line 94, in Connect
    return Connection(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/pymysql/connections.py", line 325, in __init__
    self.connect()
  File "/usr/local/lib/python3.7/dist-packages/pymysql/connections.py", line 598, in connect
    self._get_server_information()
  File "/usr/local/lib/python3.7/dist-packages/pymysql/connections.py", line 975, in _get_server_information
    packet = self._read_packet()
  File "/usr/local/lib/python3.7/dist-packages/pymysql/connections.py", line 671, in _read_packet
    % (packet_number, self._next_seq_id))
fatal: [web01]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "ca_cert": null,
            "client_cert": null,
            "client_key": null,
            "collation": "",
            "config_file": "/root/.my.cnf",
            "connect_timeout": 30,
            "encoding": "",
            "ignore_tables": [],
            "login_host": "localhost",
            "login_password": null,
            "login_port": 3306,
            "login_unix_socket": null,
            "login_user": null,
            "name": [
                "test"
            ],
            "quick": true,
            "single_transaction": false,
            "state": "absent",
            "target": null
        }
    },
    "msg": "unable to connect to database, check login_user and login_password are correct or /root/.my.cnf has the credentials. Exception message: Packet sequence number wrong - got 1 expected 0"
}
```

Notable variables in this context : 
```yaml
mysql_packages:
  - mariadb-common
  - mariadb-client
  - mariadb-server
mysql_socket: /var/run/mysqld/mysqld.sock
mysql_python_package_debian: python3-mysqldb
ansible_python_interpreter: /usr/bin/python3

```
This also happens later on the _Ensure MySQL users are present._ task. 

Making path to mysql_socket explicit inside mysql_ related ansible modules seems to fix the problem (login_unix_socket module parameter)
