### PR TITLE
Fix a fact of discovered interpreter

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -9,7 +9,7 @@
 
 - name: Determine required MySQL Python libraries.
   set_fact:
-    mysql_python_package_debian: "{% if 'python3' in ansible_python_interpreter|default('') %}python3-mysqldb{% else %}python-mysqldb{% endif %}"
+    mysql_python_package_debian: "{% if 'python3' in discovered_interpreter_python|default('') %}python3-mysqldb{% else %}python-mysqldb{% endif %}"
   when: mysql_python_package_debian is not defined
 
 - name: Ensure MySQL Python libraries are installed.


### PR DESCRIPTION
It seems that "ansible_python_interpreter" is used [to explicitly configure a Python 3 interpreter](https://docs.ansible.com/ansible/latest/reference_appendices/python_3_support.html#using-python-3-on-the-managed-machines-with-commands-and-playbooks).

The gathered fact on the managed host python interpreter could be "discovered_interpreter_python".