### PR TITLE
no_log added to secure-installation.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,9 @@ mysql_root_password: root
 mysql_root_password_update: false
 mysql_user_password_update: false
 
+# Set this to `false` to disable _ansible_no_log
+mysql_no_log: true
+
 mysql_enabled_on_startup: true
 
 # Whether my.cnf should be updated on every run.

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -15,6 +15,7 @@
     dest: "{{ mysql_user_home }}/.my.cnf"
     owner: "{{ mysql_user_name }}"
     mode: 0600
+  no_log: "{{ mysql_no_log }}"
   when: >
     mysql_user_name != mysql_root_username
     and (mysql_install_packages | bool or mysql_user_password_update)
@@ -45,6 +46,7 @@
     'ALTER USER "{{ mysql_root_username }}"@"{{ item }}"
     IDENTIFIED WITH mysql_native_password BY "{{ mysql_root_password }}";'
   with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
+  no_log: "{{ mysql_no_log }}"
   when: >
     ((mysql_install_packages | bool) or mysql_root_password_update)
     and ('5.7.' in mysql_cli_version.stdout or '8.0.' in mysql_cli_version.stdout)
@@ -55,6 +57,7 @@
     mysql -NBe
     'SET PASSWORD FOR "{{ mysql_root_username }}"@"{{ item }}" = PASSWORD("{{ mysql_root_password }}");'
   with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
+  no_log: "{{ mysql_no_log }}"
   when: >
     ((mysql_install_packages | bool) or mysql_root_password_update)
     and ('5.7.' not in mysql_cli_version.stdout and '8.0.' not in mysql_cli_version.stdout)
@@ -67,6 +70,7 @@
     owner: root
     group: root
     mode: 0600
+  no_log: "{{ mysql_no_log }}"
   when: mysql_install_packages | bool or mysql_root_password_update
 
 - name: Get list of hosts for the anonymous user.


### PR DESCRIPTION
Don't log plaintext passwords to log files.  