### PR TITLE
Fixing role for MariaDB > 10.4.3

### DIFF
--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -4,5 +4,6 @@
     name: "{{ item.name }}"
     collation: "{{ item.collation | default('utf8_general_ci') }}"
     encoding: "{{ item.encoding | default('utf8') }}"
+    login_unix_socket: "{{ login_unix_socket | default(omit) }}"
     state: "{{ item.state | default('present') }}"
   with_items: "{{ mysql_databases }}"

--- a/tasks/replication.yml
+++ b/tasks/replication.yml
@@ -3,6 +3,7 @@
   mysql_user:
     name: "{{ mysql_replication_user.name }}"
     host: "{{ mysql_replication_user.host | default('%') }}"
+    login_unix_socket: "{{ login_unix_socket | default(omit) }}"
     password: "{{ mysql_replication_user.password }}"
     priv: "{{ mysql_replication_user.priv | default('*.*:REPLICATION SLAVE,REPLICATION CLIENT') }}"
     state: present
@@ -17,6 +18,7 @@
     mode: getslave
     login_user: "{{ mysql_replication_user.name }}"
     login_password: "{{ mysql_replication_user.password }}"
+    login_unix_socket: "{{ login_unix_socket | default(omit) }}"
   ignore_errors: true
   register: slave
   when:
@@ -25,7 +27,9 @@
   tags: ['skip_ansible_galaxy']
 
 - name: Check master replication status.
-  mysql_replication: mode=getmaster
+  mysql_replication: 
+    mode: getmaster
+    login_unix_socket: "{{ login_unix_socket | default(omit) }}"
   delegate_to: "{{ mysql_replication_master }}"
   register: master
   when:
@@ -40,6 +44,7 @@
     master_host: "{{ mysql_replication_master }}"
     master_user: "{{ mysql_replication_user.name }}"
     master_password: "{{ mysql_replication_user.password }}"
+    login_unix_socket: "{{ login_unix_socket | default(omit) }}"
     master_log_file: "{{ master.File }}"
     master_log_pos: "{{ master.Position }}"
   ignore_errors: true
@@ -50,7 +55,9 @@
     - (mysql_replication_master | length) > 0
 
 - name: Start replication.
-  mysql_replication: mode=startslave
+  mysql_replication: 
+    mode: startslave
+    login_unix_socket: "{{ login_unix_socket | default(omit) }}"
   when:
     - (slave.Is_Slave is defined and not slave.Is_Slave) or (slave.Is_Slave is not defined and slave is failed)
     - mysql_replication_role == 'slave'

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -4,6 +4,7 @@
     name: "{{ mysql_user_name }}"
     host: 'localhost'
     password: "{{ mysql_user_password }}"
+    login_unix_socket: "{{ login_unix_socket | default(omit) }}"
     priv: '*.*:ALL,GRANT'
     state: present
   when: mysql_user_name != mysql_root_username
@@ -79,8 +80,12 @@
   mysql_user:
     name: ""
     host: "{{ item }}"
+    login_unix_socket: "{{ login_unix_socket | default(omit) }}"
     state: absent
   with_items: "{{ mysql_anonymous_hosts.stdout_lines|default([]) }}"
 
 - name: Remove MySQL test database.
-  mysql_db: "name='test' state=absent"
+  mysql_db: 
+    name: "test"
+    login_unix_socket: "{{ login_unix_socket | default(omit) }}"
+    state: absent

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -6,6 +6,7 @@
     password: "{{ item.password }}"
     priv: "{{ item.priv | default('*.*:USAGE') }}"
     state: "{{ item.state | default('present') }}"
+    login_unix_socket: "{{ login_unix_socket | default(omit) }}"
     append_privs: "{{ item.append_privs | default('no') }}"
     encrypted: "{{ item.encrypted | default('no') }}"
   with_items: "{{ mysql_users }}"


### PR DESCRIPTION
Since MariaDB 10.4.3 release, default authentication plugin for 'root'@'localhost' has been set.

This change is preventing Ansible mysql modules as used in the role to work.
`login_unix_socket` option can been used to avoid these modules from failing.

