### PR TITLE
Fixes #412: Flush privileges after root account password update

### DIFF
--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -43,7 +43,7 @@
   shell: >
     mysql -u root -NBe
     'ALTER USER "{{ mysql_root_username }}"@"{{ item }}"
-    IDENTIFIED WITH mysql_native_password BY "{{ mysql_root_password }}";'
+    IDENTIFIED WITH mysql_native_password BY "{{ mysql_root_password }}"; FLUSH PRIVILEGES;'
   with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
   when: >
     ((mysql_install_packages | bool) or mysql_root_password_update)
@@ -53,7 +53,7 @@
 - name: Update MySQL root password for localhost root account (< 5.7.x).
   shell: >
     mysql -NBe
-    'SET PASSWORD FOR "{{ mysql_root_username }}"@"{{ item }}" = PASSWORD("{{ mysql_root_password }}");'
+    'SET PASSWORD FOR "{{ mysql_root_username }}"@"{{ item }}" = PASSWORD("{{ mysql_root_password }}"); FLUSH PRIVILEGES;'
   with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
   when: >
     ((mysql_install_packages | bool) or mysql_root_password_update)


### PR DESCRIPTION
Hi!

Thanks a lot for your so useful Ansible role!
I unfortunately had some problems to run the role without getting an error after the root password has been set or changed.

I left a comment about it on the issue : https://github.com/geerlingguy/ansible-role-mysql/issues/412#issuecomment-717366818

This would be a quick fix but probably not the cleanest.

A better option would be to build the SQL query first in a task using the `with_items` and then run the mysql query in another task so that we can add the flush of privileges at this moment only. But I don't think it's very time consuming to flush the privileges more than once for the case where we have multiple hosts (probably not so often).

Best regards,

Patrick