### PR TITLE
Add mysql_uers_no_log to debug user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ The MySQL users and their privileges. A user has the values:
   - `append_privs` (defaults to `no`)
   - `state`  (defaults to `present`)
 
+A list of users to ensure exist on the server. Only the name is required; all other properties are optional.
+
+    mysql_users_no_log: true
+
+Whether to output user data (which may contain sensitive information, like passwords) when managing users.
+
 The formats of these are the same as in the `mysql_user` module.
 
     mysql_packages:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -120,6 +120,9 @@ mysql_users: []
 #     priv: *.*:USAGE
 
 # Replication settings (replication is only enabled if master/user have values).
+
+# Whether to output user data when managing users.
+mysql_users_no_log: true
 mysql_server_id: "1"
 mysql_max_binlog_size: "100M"
 mysql_binlog_format: "ROW"

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -9,4 +9,4 @@
     append_privs: "{{ item.append_privs | default('no') }}"
     encrypted: "{{ item.encrypted | default('no') }}"
   with_items: "{{ mysql_users }}"
-  no_log: true
+  no_log: "{{ mysql_users_no_log | bool }}"


### PR DESCRIPTION
The `mysql_uers_no_log` controls the `no_log` property when creating
mysql users. Whilst this is usefull for not disclosing credentials, it
hinders debugging.

This was borrowed from from the ansible-role-postgresql[^0] and is
implemented the same way.

[^0]: https://github.com/geerlingguy/ansible-role-postgresql