### PR TITLE
Add small documentation about replication

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Slow query log settings. Note that the log file will be created by this role, bu
 
 The rest of the settings in `defaults/main.yml` control MySQL's memory usage and some other common settings. The default values are tuned for a server where MySQL can consume ~512 MB RAM, so you should consider adjusting them to suit your particular server better.
 
+### Replication settings
+
     mysql_server_id: "1"
     mysql_max_binlog_size: "100M"
     mysql_binlog_format: "ROW"
@@ -124,9 +126,9 @@ The rest of the settings in `defaults/main.yml` control MySQL's memory usage and
     mysql_replication_master: ''
     mysql_replication_user: {}
 
-Replication settings. Set `mysql_server_id` and `mysql_replication_role` by server (e.g. the master would be ID `1`, with the `mysql_replication_role` of `master`, and the slave would be ID `2`, with the `mysql_replication_role` of `slave`). The `mysql_replication_user` uses the same keys as individual list items in `mysql_users`, and is created on master servers, and used to replicate on all the slaves.
+Set `mysql_server_id` and `mysql_replication_role` by server (e.g. the master would be ID `1`, with the `mysql_replication_role` of `master`, and the slave would be ID `2`, with the `mysql_replication_role` of `slave`). The `mysql_replication_user` uses the same keys as individual list items in `mysql_users`, and is created on master servers, and used to replicate on all the slaves.
 
-`mysql_replication_master` needs to resolve to an IP or a hostname which is accessable to the Slaves (this could be a `/etc/hosts` injection or some other means), otherwise the slaves cannot communicate to the master.
+`mysql_replication_master` needs to be defined on master and slaves and to resolve to an IP or a hostname which is accessable to the Slaves (this could be a `/etc/hosts` injection or some other means), otherwise the slaves cannot communicate to the master.
 
 ### Later versions of MySQL on CentOS 7
 


### PR DESCRIPTION
This is not clear (at least to me) it was necessary to define `mysql_replication_master` even on the master node so adding this to README.