### PR TITLE
Remove login_user and login_password from getslave operation

### DIFF
--- a/tasks/replication.yml
+++ b/tasks/replication.yml
@@ -15,8 +15,6 @@
 - name: Check slave replication status.
   mysql_replication:
     mode: getslave
-    login_user: "{{ mysql_replication_user.name }}"
-    login_password: "{{ mysql_replication_user.password }}"
   ignore_errors: true
   register: slave
   when:


### PR DESCRIPTION
Replication user is not created on the slave, but root works just fine.

Should fix https://github.com/geerlingguy/ansible-role-mysql/issues/435