### PR TITLE
Document that the non-root user password can be updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ The home directory inside which Python MySQL settings will be stored, which Ansi
 The MySQL root user account details.
 
     mysql_root_password_update: false
+    mysql_user_password_update: false
 
-Whether to force update the MySQL root user's password. By default, this role will only change the root user's password when MySQL is first configured. You can force an update by setting this to `yes`.
+Whether to force update the passwords of the MySQL root user and the non-root user. By default, this role will only change the users' passwords when MySQL is first configured. You can force an update by setting this to `yes`.
 
 > Note: If you get an error like `ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES)` after a failed or interrupted playbook run, this usually means the root password wasn't originally updated to begin with. Try either removing  the `.my.cnf` file inside the configured `mysql_user_home` or updating it and setting `password=''` (the insecure default password). Run the playbook again, with `mysql_root_password_update` set to `yes`, and the setup should complete.
 


### PR DESCRIPTION
I am using a non-root user to manage the database and I wanted to change this user's password but it was not immediately clear from the documentation how to do this.