### PR TITLE
Drop off j2 file suffix from template src in mysql_config_include_files variable

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -27,7 +27,7 @@
 - name: Copy my.cnf override files into include directory.
   template:
     src: "{{ item.src }}"
-    dest: "{{ mysql_config_include_dir }}/{{ item.src | basename }}"
+    dest: "{{ mysql_config_include_dir }}/{{ item.src | basename | regex_replace('\\.j2$', '') }}"
     owner: root
     group: root
     mode: 0644


### PR DESCRIPTION
We are used to have the .j2 suffix attached for template file. For me it makes sense to remove it when determining the file name for the MySQL configuration file. Otherwise you may end up with a file which is ignored by MySQL.