### PR TITLE
fix to 'mysqld.err Permission denied' error when using mysql 5.7

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -66,8 +66,8 @@
     creates: "{{ mysql_log_error }}"
     warn: false
   when:
-    - mysql_log | default(true)
-    - mysql_log_error | default(false)
+    - (mysql_log | default(true)) or ('5.7.' in mysql_cli_version.stdout)
+    - (mysql_log_error | default(false)) or ('5.7.' in mysql_cli_version.stdout)
   tags: ['skip_ansible_galaxy']
 
 - name: Set ownership on error log file (if configured).
@@ -78,8 +78,8 @@
     group: "{{ mysql_log_file_group }}"
     mode: 0640
   when:
-    - mysql_log | default(true)
-    - mysql_log_error | default(false)
+    - (mysql_log | default(true)) or ('5.7.' in mysql_cli_version.stdout)
+    - (mysql_log_error | default(false)) or ('5.7.' in mysql_cli_version.stdout)
   tags: ['skip_ansible_galaxy']
 
 - name: Ensure MySQL is started and enabled on boot.


### PR DESCRIPTION
[ERROR] Could not open file '/var/log/mysqld.err' for error logging: Permission denied
which appears to be the same issues as here:
https://github.com/geerlingguy/ansible-role-mysql/issues/418