### PR TITLE
Fix mysql tasks when using custom socket

### DIFF
--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -2,6 +2,7 @@
 - name: Ensure MySQL databases are present.
   mysql_db:
     name: "{{ item.name }}"
+    login_unix_socket: "{{ mysql_socket }}"
     collation: "{{ item.collation | default('utf8_general_ci') }}"
     encoding: "{{ item.encoding | default('utf8') }}"
     state: "{{ item.state | default('present') }}"

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -4,6 +4,7 @@
     name: "{{ mysql_user_name }}"
     host: 'localhost'
     password: "{{ mysql_user_password }}"
+    login_unix_socket: "{{ mysql_socket }}"
     priv: '*.*:ALL,GRANT'
     state: present
   when: mysql_user_name != mysql_root_username
@@ -79,8 +80,12 @@
   mysql_user:
     name: ""
     host: "{{ item }}"
+    login_unix_socket: "{{ mysql_socket }}"
     state: absent
   with_items: "{{ mysql_anonymous_hosts.stdout_lines|default([]) }}"
 
 - name: Remove MySQL test database.
-  mysql_db: "name='test' state=absent"
+  mysql_db:
+    name: "test"
+    login_unix_socket: "{{ mysql_socket }}"
+    state: absent

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -4,6 +4,7 @@
     name: "{{ item.name }}"
     host: "{{ item.host | default('localhost') }}"
     password: "{{ item.password }}"
+    login_unix_socket: "{{ mysql_socket }}"
     priv: "{{ item.priv | default('*.*:USAGE') }}"
     state: "{{ item.state | default('present') }}"
     append_privs: "{{ item.append_privs | default('no') }}"


### PR DESCRIPTION
Update all tasks interacting with the MySQL db on the system to use the
configured socket. Otherwise setting the mysql_socket variable to
something different from the default will result in errors since the
tasks can not connect to the db.

From : https://github.com/geerlingguy/ansible-role-mysql/pull/351