### PR TITLE
Fix #462 and add missing configuration properties

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,6 +58,7 @@ mysql_slow_query_time: "2"
 # Memory settings (default values optimized ~512MB RAM).
 mysql_key_buffer_size: "256M"
 mysql_max_allowed_packet: "64M"
+mysql_table_definition_cache: ""
 mysql_table_open_cache: "256"
 mysql_sort_buffer_size: "1M"
 mysql_read_buffer_size: "1M"
@@ -68,6 +69,7 @@ mysql_query_cache_type: "0"
 mysql_query_cache_size: "16M"
 mysql_query_cache_limit: "1M"
 mysql_max_connections: "151"
+mysql_temptable_max_ram: ""
 mysql_tmp_table_size: "16M"
 mysql_max_heap_table_size: "16M"
 mysql_group_concat_max_len: "1024"
@@ -124,6 +126,7 @@ mysql_server_id: "1"
 mysql_max_binlog_size: "100M"
 mysql_binlog_format: "ROW"
 mysql_expire_logs_days: "10"
+mysql_binlog_expire_logs_seconds: ""
 mysql_replication_role: ''
 mysql_replication_master: ''
 # Same keys as `mysql_users` above.

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -95,7 +95,7 @@ query_cache_limit = {{ mysql_query_cache_limit }}
 {% endif %}
 max_connections = {{ mysql_max_connections }}
 {% if mysql_temptable_max_ram %}
-temptable_max_ram: {{ mysql_temptable_max_ram }}
+temptable_max_ram = {{ mysql_temptable_max_ram }}
 {% endif %}
 tmp_table_size = {{ mysql_tmp_table_size }}
 max_heap_table_size = {{ mysql_max_heap_table_size }}

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -43,7 +43,11 @@ server-id = {{ mysql_server_id }}
 {% if mysql_replication_role == 'master' %}
 log_bin = mysql-bin
 log-bin-index = mysql-bin.index
+{% if mysql_binlog_expire_logs_seconds %}
+binlog_expire_logs_seconds = {{ mysql_binlog_expire_logs_seconds }}
+{% else %}
 expire_logs_days = {{ mysql_expire_logs_days }}
+{% endif %}
 max_binlog_size = {{ mysql_max_binlog_size }}
 binlog_format = {{mysql_binlog_format}}
 
@@ -75,6 +79,9 @@ user = mysql
 # Memory settings.
 key_buffer_size = {{ mysql_key_buffer_size }}
 max_allowed_packet = {{ mysql_max_allowed_packet }}
+{% if mysql_table_definition_cache %}
+table_definition_cache = {{ mysql_table_definition_cache }}
+{% endif %}
 table_open_cache = {{ mysql_table_open_cache }}
 sort_buffer_size = {{ mysql_sort_buffer_size }}
 read_buffer_size = {{ mysql_read_buffer_size }}
@@ -87,6 +94,9 @@ query_cache_size = {{ mysql_query_cache_size }}
 query_cache_limit = {{ mysql_query_cache_limit }}
 {% endif %}
 max_connections = {{ mysql_max_connections }}
+{% if mysql_temptable_max_ram %}
+temptable_max_ram: {{ mysql_temptable_max_ram }}
+{% endif %}
 tmp_table_size = {{ mysql_tmp_table_size }}
 max_heap_table_size = {{ mysql_max_heap_table_size }}
 group_concat_max_len = {{ mysql_group_concat_max_len }}


### PR DESCRIPTION
Allows to confgure `binlog_expire_logs_seconds`, `table_definition_cache`, `temptable_max_ram`.
#462 is fixed.