### PR TITLE
Issue #223: Generate a random default root password

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,14 +1,17 @@
 ---
+# Set a random password.
+mysql_password: "{{ lookup('password', '/dev/null length=20 chars=ascii_letters') }}"
+
 # Set this to the user ansible is logging in as - should have root
 # or sudo access
 mysql_user_home: /root
 mysql_user_name: root
-mysql_user_password: "{{ lookup('password', '/dev/null length=20 chars=ascii_letters') }}"
+mysql_user_password: "{{ mysql_password }}"
 
 # The default root user installed by mysql - almost always root
 mysql_root_home: /root
 mysql_root_username: root
-mysql_root_password: root
+mysql_root_password: "{{ mysql_password }}"
 
 # Set this to `true` to forcibly update the root password.
 mysql_root_password_update: false


### PR DESCRIPTION
Instead of hardcoding an insecure default password for the `root` mysql user, generate a random one as discussed in issue #223 .