### PR TITLE
Debian 11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           - ubuntu2004
           - ubuntu1804
           - debian10
+          - debian11
 
     steps:
       - name: Check out the codebase.

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check if MySQL is already installed.
-  stat: path=/etc/init.d/mysql
+  stat: "path=/etc/init.d/{{ mysql_daemon }}"
   register: mysql_installed
 
 - name: Update apt cache if MySQL is not yet installed.

--- a/vars/Debian-11.yml
+++ b/vars/Debian-11.yml
@@ -1,0 +1,13 @@
+---
+__mysql_daemon: mariadb
+__mysql_packages:
+  - default-mysql-server
+mysql_log_file_group: adm
+__mysql_slow_query_log_file: /var/log/mysql/mysql-slow.log
+__mysql_log_error: /var/log/mysql/mysql.log
+__mysql_syslog_tag: mariadb
+__mysql_pid_file: /run/mysqld/mysqld.pid
+__mysql_config_file: /etc/mysql/my.cnf
+__mysql_config_include_dir: /etc/mysql/conf.d
+__mysql_socket: /run/mysqld/mysqld.sock
+__mysql_supports_innodb_large_prefix: true

--- a/vars/Debian-11.yml
+++ b/vars/Debian-11.yml
@@ -3,9 +3,9 @@ __mysql_daemon: mariadb
 __mysql_packages:
   - default-mysql-server
 mysql_log_file_group: adm
-__mysql_slow_query_log_file: /var/log/mysql/mysql-slow.log
+__mysql_slow_query_log_file: /var/log/mysql/mariadb-slow.log
 __mysql_log_error: /var/log/mysql/mysql.log
-__mysql_syslog_tag: mariadb
+__mysql_syslog_tag: mysqld
 __mysql_pid_file: /run/mysqld/mysqld.pid
 __mysql_config_file: /etc/mysql/my.cnf
 __mysql_config_include_dir: /etc/mysql/conf.d


### PR DESCRIPTION
This adds debian 11 support. Most of the work has been done by @smallsam already in #457 . This only includes a fix to make the installation on debian 11 idempotent, which was suggested by @SchizoDuckie .