### PR TITLE
Support RHEL9 family

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       matrix:
         distro:
           - rockylinux8
+          - rockylinux9
           - centos7
           - ubuntu2004
           - ubuntu1804

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,7 @@ galaxy_info:
       versions:
         - 7
         - 8
+        - 9
     - name: Ubuntu
       versions:
         - all

--- a/vars/RedHat-9.yml
+++ b/vars/RedHat-9.yml
@@ -1,0 +1,18 @@
+---
+__mysql_daemon: mariadb
+__mysql_packages:
+  - mariadb
+  - mariadb-server
+  - mariadb-connector-c
+  - python3-PyMySQL
+  - perl-DBD-MySQL
+__mysql_slow_query_log_file: /var/log/mysql-slow.log
+__mysql_log_error: /var/log/mariadb/mariadb.log
+__mysql_syslog_tag: mariadb
+__mysql_pid_file: /var/run/mariadb/mariadb.pid
+__mysql_config_file: /etc/my.cnf
+__mysql_config_include_dir: /etc/my.cnf.d
+__mysql_socket: /var/lib/mysql/mysql.sock
+# The entries controlled by this value should not be used with MariaDB >= 10.2.2
+# See https://github.com/frappe/bench/issues/681#issuecomment-398984706
+__mysql_supports_innodb_large_prefix: false


### PR DESCRIPTION
Copying the vars from RHEL8 was sufficient to make it work on the current CentOS9 Stream release.