### PR TITLE
Issue #479 : [FIX] MySQL apt key

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -3,6 +3,12 @@
   stat: path=/etc/init.d/{{ mysql_daemon }}
   register: mysql_installed
 
+- name: Add MySQL apt key.
+  apt_key:
+    url: https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
+    state: present
+  when: not mysql_installed.stat.exists
+
 - name: Update apt cache if MySQL is not yet installed.
   apt: update_cache=yes
   changed_when: False


### PR DESCRIPTION
Issue : https://github.com/geerlingguy/ansible-role-mysql/issues/479

Since the beginning of 2022, the GPG keys for the official MySQL repository have expired preventing installation or update of MySQL packages.

Bug discussion : https://bugs.mysql.com/bug.php?id=106188

Release note : https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-37.html