### PR TITLE
Added support for database state import

### DIFF
--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -5,4 +5,5 @@
     collation: "{{ item.collation | default('utf8_general_ci') }}"
     encoding: "{{ item.encoding | default('utf8') }}"
     state: "{{ item.state | default('present') }}"
+    target: "{{ item.target | default(omit) }}"
   with_items: "{{ mysql_databases }}"


### PR DESCRIPTION
mysql_db when using state 'import' requires extra target parameter, added it to the task with default(omit)