### PR TITLE
Add option to disable binlog

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -119,7 +119,7 @@ mysql_users: []
 #     password: secret
 #     priv: *.*:USAGE
 
-mysql_disable_log_bin: "false"
+mysql_disable_log_bin: false
 
 # Replication settings (replication is only enabled if master/user have values).
 mysql_server_id: "1"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -119,6 +119,8 @@ mysql_users: []
 #     password: secret
 #     priv: *.*:USAGE
 
+mysql_disable_log_bin: "false"
+
 # Replication settings (replication is only enabled if master/user have values).
 mysql_server_id: "1"
 mysql_max_binlog_size: "100M"

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -36,6 +36,12 @@ slow_query_log_file = {{ mysql_slow_query_log_file }}
 long_query_time = {{ mysql_slow_query_time }}
 {% endif %}
 
+
+{% if mysql_disable_log_bin and not mysql_replication_master%}
+# Disable binlog to save disk space
+disable-log-bin
+{% endif %}
+
 {% if mysql_replication_master %}
 # Replication
 server-id = {{ mysql_server_id }}

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -37,7 +37,7 @@ long_query_time = {{ mysql_slow_query_time }}
 {% endif %}
 
 
-{% if mysql_disable_log_bin and not mysql_replication_master%}
+{% if mysql_disable_log_bin and not mysql_replication_master %}
 # Disable binlog to save disk space
 disable-log-bin
 {% endif %}


### PR DESCRIPTION
According to the [mysql dokumentation](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#option_mysqld_log-bin) log-bin is enabled by default and can be disabled using the `disable-log-bin` option. 

Currently it is not possible to disable the log with this ansible role. On unreplicated installations the log is not needed and may induce a significant storage overhead. 

This PR adds an option to disable the log explicitly with a `mysql_disable_log_bin` variable. The log has to be disabled explicitly. 