### PR TITLE
Fix error in query with sql_mode ANSI_QUOTES

### DIFF
--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -70,7 +70,7 @@
   when: mysql_install_packages | bool or mysql_root_password_update
 
 - name: Get list of hosts for the anonymous user.
-  command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = ""'
+  command: mysql -NBe "SELECT Host FROM mysql.user WHERE User = ''"
   register: mysql_anonymous_hosts
   changed_when: false
   check_mode: false


### PR DESCRIPTION
When MySQL is configured to use [sql_mode ANSI_QUOTES](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_ansi_quotes), the query in tasks/secure-installation.yml fails:
```
TASK [geerlingguy.mysql : Get list of hosts for the anonymous user.] **************************************************************************************************************************************
fatal: [0.0.0.0]: FAILED! => {"changed": false, "cmd": ["mysql", "-NBe", "SELECT Host FROM mysql.user WHERE User = \"\""], "delta": "0:00:00.015942", "end": "2022-08-10 18:27:01.544215", "msg": "non-zero return code", "rc": 1, "start": "2022-08-10 18:27:01.528273", "stderr": "ERROR 1054 (42S22) at line 1: Unknown column '' in 'where clause'", "stderr_lines": ["ERROR 1054 (42S22) at line 1: Unknown column '' in 'where clause'"], "stdout": "", "stdout_lines": []}
```

This happens because with this mode mysql treats " _as an identifier quote character (like the ` quote character) and not as a string quote character_.