### PR TITLE
Allow replica master to be differ from local inventory + fix Is_Replica or Is_Slave

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Replication settings. Set `mysql_server_id` and `mysql_replication_role` by serv
 
 `mysql_replication_master` needs to resolve to an IP or a hostname which is accessable to the Slaves (this could be a `/etc/hosts` injection or some other means), otherwise the slaves cannot communicate to the master.
 
-If the replication master has different IP addresses where you are running ansible and where the mysql replica is running, you can *optionally* specify a `mysql_replication_master_inventory_host` to access the machine (e.g. you run ansible on your local machine, but the mysql master and replica need to communicate behind a vpn)
+If the replication master has different IP addresses where you are running ansible and where the mysql replica is running, you can *optionally* specify a `mysql_replication_master_inventory_host` to access the machine (e.g. you run ansible on your local machine, but the mysql master and replica need to communicate on a different network)
 
 ### Later versions of MySQL on CentOS 7
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ Replication settings. Set `mysql_server_id` and `mysql_replication_role` by serv
 
 `mysql_replication_master` needs to resolve to an IP or a hostname which is accessable to the Slaves (this could be a `/etc/hosts` injection or some other means), otherwise the slaves cannot communicate to the master.
 
+If the replication master has different IP addresses where you are running ansible and where the mysql replica is running, you can *optionally* specify a `mysql_replication_master_inventory_host` to access the machine (e.g. you run ansible on your local machine, but the mysql master and replica need to communicate behind a vpn)
+
 ### Later versions of MySQL on CentOS 7
 
 If you want to install MySQL from the official repository instead of installing the system default MariaDB equivalents, you can add the following `pre_tasks` task in your playbook:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -128,5 +128,7 @@ mysql_binlog_format: "ROW"
 mysql_expire_logs_days: "10"
 mysql_replication_role: ''
 mysql_replication_master: ''
+mysql_replication_master_inventory_host: "{{ mysql_replication_master }}"
+
 # Same keys as `mysql_users` above.
 mysql_replication_user: []

--- a/tasks/replication.yml
+++ b/tasks/replication.yml
@@ -26,7 +26,7 @@
 
 - name: Check master replication status.
   mysql_replication: mode=getprimary
-  delegate_to: "{{ mysql_replication_master }}"
+  delegate_to: "{{ mysql_replication_master_inventory_host }}"
   register: master
   when:
     - (slave.Is_Slave is defined and not slave.Is_Slave) or (slave.Is_Slave is not defined and slave is failed)

--- a/tasks/replication.yml
+++ b/tasks/replication.yml
@@ -29,7 +29,7 @@
   delegate_to: "{{ mysql_replication_master_inventory_host }}"
   register: master
   when:
-    - (slave.Is_Slave is defined and not slave.Is_Slave) or (slave.Is_Slave is not defined and slave is failed)
+    - (slave.Is_Slave is defined and not slave.Is_Slave) or (slave.Is_Replica is defined and not slave.Is_Replica) or (slave.Is_Slave is not defined and slave.Is_Replica is not defined and slave is failed)
     - mysql_replication_role == 'slave'
     - (mysql_replication_master | length) > 0
   tags: ['skip_ansible_galaxy']
@@ -44,7 +44,7 @@
     master_log_pos: "{{ master.Position }}"
   ignore_errors: true
   when:
-    - (slave.Is_Slave is defined and not slave.Is_Slave) or (slave.Is_Slave is not defined and slave is failed)
+    - (slave.Is_Slave is defined and not slave.Is_Slave) or (slave.Is_Replica is defined and not slave.Is_Replica) or (slave.Is_Slave is not defined and slave.Is_Replica is not defined and slave is failed)
     - mysql_replication_role == 'slave'
     - mysql_replication_user.name is defined
     - (mysql_replication_master | length) > 0


### PR DESCRIPTION
E.g.
I am running ansible on my local machine and they are accessible over public IP but i want the master and the slave to communicate over some other network interface card.

`mysql_replication_master_inventory_host` defaults to `mysql_replication_master` so it's a non-breaking change