### PR TITLE
Remove `warn` as it disappeared in Ansible 7

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -39,7 +39,6 @@
   command: "touch {{ mysql_slow_query_log_file }}"
   args:
     creates: "{{ mysql_slow_query_log_file }}"
-    warn: false
   when: mysql_slow_query_log_enabled
 
 - name: Create datadir if it does not exist
@@ -64,7 +63,6 @@
   command: "touch {{ mysql_log_error }}"
   args:
     creates: "{{ mysql_log_error }}"
-    warn: false
   when:
     - mysql_log | default(true)
     - mysql_log_error | default(false)


### PR DESCRIPTION
More at https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_7.html#removed-features