### PR TITLE
Add mysqlx variables to my.cnf

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,8 @@ mysql_python_package_debian: python3-mysqldb
 # MySQL connection settings.
 mysql_port: "3306"
 mysql_bind_address: '0.0.0.0'
+mysqlx_port: "3306"
+mysqlx_bind_address: '0.0.0.0'
 mysql_skip_name_resolve: false
 mysql_datadir: /var/lib/mysql
 mysql_sql_mode: ~

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,7 @@ mysql_python_package_debian: python3-mysqldb
 # MySQL connection settings.
 mysql_port: "3306"
 mysql_bind_address: '0.0.0.0'
-mysqlx_port: "3306"
+mysqlx_port: "33060"
 mysqlx_bind_address: '0.0.0.0'
 mysql_skip_name_resolve: false
 mysql_datadir: /var/lib/mysql

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -8,6 +8,8 @@ socket = {{ mysql_socket }}
 [mysqld]
 port = {{ mysql_port }}
 bind-address = {{ mysql_bind_address }}
+mysqlx-port = {{ mysqlx_port }}
+mysqlx-bind-address = {{ mysqlx_bind_address }}
 datadir = {{ mysql_datadir }}
 socket = {{ mysql_socket }}
 pid-file = {{ mysql_pid_file }}


### PR DESCRIPTION
This change let you customize the `mysqlx-port` and `mysqlx-bind-address` in order to stop mysqlx plugin to listen on all interfaces. Fix for #415 