### PR TITLE
Fix replication not starting.

### DIFF
--- a/tasks/replication.yml
+++ b/tasks/replication.yml
@@ -52,7 +52,7 @@
 - name: Start replication.
   mysql_replication: mode=startreplica
   when:
-    - (slave.Is_Slave is defined and not slave.Is_Slave) or (slave.Is_Slave is not defined and slave is failed)
+    - (slave.Is_Slave is defined and slave.Is_Slave) or (slave.Is_Replica is defined and slave.Is_Replica) or (slave.Is_Slave is not defined and slave.Is_Replica is not defined and slave is failed)
     - mysql_replication_role == 'slave'
     - (mysql_replication_master | length) > 0
   tags: ['skip_ansible_galaxy']


### PR DESCRIPTION
Fofllow-up to #503. That PR didn't include `Is_Replica` in its `Start replication.` task.

In addition I found that the previous logic of running `Start replication.` when `not slave.Is_Slave` would never start the replica, since `slave.Is_Slave` would evaluate to `true`. The reason being the replication _is_ setup, it just hasn't been started yet, so this PR also fixes that.