### PR TITLE
Bug corrected when updating mysql root password

### DIFF
--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -42,8 +42,8 @@
 - name: Update MySQL root password for localhost root account (5.7.x).
   shell: >
     mysql -u root -NBe
-    'ALTER USER "{{ mysql_root_username }}"@"{{ item }}"
-    IDENTIFIED WITH mysql_native_password BY "{{ mysql_root_password }}"; FLUSH PRIVILEGES;'
+    "ALTER USER '{{ mysql_root_username }}'@'{{ item }}'
+     IDENTIFIED WITH mysql_native_password BY '{{ mysql_root_password }}'; FLUSH PRIVILEGES;"
   with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
   when: >
     ((mysql_install_packages | bool) or mysql_root_password_update)


### PR DESCRIPTION
Bug corrected when updating mysql root password for localhost root account (5.7.x).

```
failed: [hostname] (item=localhost) => {"ansible_loop_var": "item", "changed": true, "cmd": "mysql -u root -NBe 'ALTER USER \"root\"@\"localhost\" IDENTIFIED WITH mysql_native_password BY \"xxxxx\"; FLUSH PRIVILEGES;'\n", "delta": "0:00:00.013884", "end": "2023-01-09 11:15:43.965674", "item": "localhost", "msg": "non-zero return code", "rc": 1, "start": "2023-01-09 11:15:43.951790", "stderr": "ERROR 1064 (42000) at line 1: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '\"xxxxx\"' at line 1", "stderr_lines": ["ERROR 1064 (42000) at line 1: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '\"xxxxx\"' at line 1"], "stdout": "", "stdout_lines": []}
```