### PR TITLE
Update configure.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -98,6 +98,7 @@ mysql_mysqldump_max_allowed_packet: "64M"
 # Logging settings.
 mysql_log: ""
 # The following variables have a default value depending on operating system.
+mysql_error_log_enabled: false
 # mysql_log_error: /var/log/mysql/mysql.err
 # mysql_syslog_tag: mysql
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -98,7 +98,7 @@ mysql_mysqldump_max_allowed_packet: "64M"
 # Logging settings.
 mysql_log: ""
 # The following variables have a default value depending on operating system.
-mysql_error_log_enabled: false
+mysql_log_error_enabled: false
 # mysql_log_error: /var/log/mysql/mysql.err
 # mysql_syslog_tag: mysql
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -51,6 +51,8 @@
     owner: mysql
     group: "{{ mysql_log_file_group }}"
     mode: 0640
+    access_time: preserve
+    modification_time: preserve
   when: mysql_slow_query_log_enabled
 
 - name: Create error log file (if configured).
@@ -60,9 +62,9 @@
     owner: mysql
     group: "{{ mysql_log_file_group }}"
     mode: 0640
-  when:
-    - mysql_log | default(true)
-    - mysql_log_error | default(false)
+    access_time: preserve
+    modification_time: preserve
+  when: mysql_log_error_enabled
   tags: ['skip_ansible_galaxy']
 
 - name: Ensure MySQL is started and enabled on boot.

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -35,12 +35,6 @@
   with_items: "{{ mysql_config_include_files }}"
   notify: restart mysql
 
-- name: Create slow query log file (if configured).
-  ansible.builtin.command: "touch {{ mysql_slow_query_log_file }}"
-  args:
-    creates: "{{ mysql_slow_query_log_file }}"
-  when: mysql_slow_query_log_enabled
-
 - name: Create datadir if it does not exist
   ansible.builtin.file:
     path: "{{ mysql_datadir }}"
@@ -50,28 +44,19 @@
     mode: 0755
     setype: mysqld_db_t
 
-- name: Set ownership on slow query log file (if configured).
+- name: Create slow query log file (if configured).
   ansible.builtin.file:
     path: "{{ mysql_slow_query_log_file }}"
-    state: file
+    state: touch
     owner: mysql
     group: "{{ mysql_log_file_group }}"
     mode: 0640
   when: mysql_slow_query_log_enabled
 
 - name: Create error log file (if configured).
-  ansible.builtin.command: "touch {{ mysql_log_error }}"
-  args:
-    creates: "{{ mysql_log_error }}"
-  when:
-    - mysql_log | default(true)
-    - mysql_log_error | default(false)
-  tags: ['skip_ansible_galaxy']
-
-- name: Set ownership on error log file (if configured).
   ansible.builtin.file:
     path: "{{ mysql_log_error }}"
-    state: file
+    state: touch
     owner: mysql
     group: "{{ mysql_log_file_group }}"
     mode: 0640


### PR DESCRIPTION
When:
1. `mysql_datadir` is not `/var/lib/mysql`.
2. `mysql_slow_query_log_file` and `mysql_log_error` use `mysql_datadir`

... then the deployment fails:
```
mysql_datadir: "/data/mysql"
mysql_slow_query_log_file: "{{ mysql_datadir }}/.mysql-slow.log"
mysql_log_error: "{{ mysql_datadir }}/.mysql-error.log"
```
```
TASK [geerlingguy.mysql : Create slow query log file (if configured).] *******************************************************************************************************
Tuesday 11 July 2023  19:58:53 +0300 (0:00:00.049)       0:02:00.408 ********** 
fatal: [vm01.vagrant.loc]: FAILED! => {"changed": true, "cmd": ["touch", "/data/mysql/.mysql-slow.log"], "delta": "0:00:00.008097", "end": "2023-07-11 16:58:53.402634", "msg": "non-zero return code", "rc": 1, "start": "2023-07-11 16:58:53.394537", "stderr": "touch: cannot touch '/data/mysql/.mysql-slow.log': No such file or directory", "stderr_lines": ["touch: cannot touch '/data/mysql/.mysql-slow.log': No such file or directory"], "stdout": "", "stdout_lines": []}
fatal: [vm02.vagrant.loc]: FAILED! => {"changed": true, "cmd": ["touch", "/data/mysql/.mysql-slow.log"], "delta": "0:00:00.005696", "end": "2023-07-11 16:58:53.405119", "msg": "non-zero return code", "rc": 1, "start": "2023-07-11 16:58:53.399423", "stderr": "touch: cannot touch '/data/mysql/.mysql-slow.log': No such file or directory", "stderr_lines": ["touch: cannot touch '/data/mysql/.mysql-slow.log': No such file or directory"], "stdout": "", "stdout_lines": []}
```
The directory `mysql_datadir` must be created before `mysql_slow_query_log_file` is created in it. This step works if `mysql_datadir` is the default, as the package creates the directory during installation.

Additionally, I suggest removing the creation of an empty file through a `command` and delegating this task to `ansible.builtin.file`.

Also, i noticed condition for step "Create error log file" wrong:
```
# Logging settings.
mysql_log: ""
# The following variables have a default value depending on operating system.
# mysql_log_error: /var/log/mysql/mysql.err
# mysql_syslog_tag: mysql
```
`mysql_log` and `mysql_log_error` are strings, while `when` expects bool. 
```
  when:
    - mysql_log | default(true)
    - mysql_log_error | default(false)
```
checking:
```
- debug:
    msg:
      - "mysql_log: {{ mysql_log }} | {{ mysql_log | type_debug }}"
      - "mysql_log_error: {{ mysql_log_error }} | {{ mysql_log_error | type_debug }}"

- ansible.builtin.assert:
    that:
      - mysql_log | default(true)
      - mysql_log_error | default(false)
```
result:
```
ok: [mysql01] => {
    "msg": [
        "mysql_log:  | AnsibleUnicode",
        "mysql_log_error: /data/mysql/.mysql-error.log | str"
    ]
}

fatal: [mysql01]: FAILED! => {
    "assertion": "mysql_log | default(true)",
    "changed": false,
    "evaluated_to": false,
    "msg": "Assertion failed"
}
```