### PR TITLE
Replace ansible.builtin.command with command module

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: restart mysql
-  ansible.builtin.service:
+  service:
     name: "{{ mysql_daemon }}"
     state: restarted
     sleep: 5

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,9 +8,9 @@
 
   post_tasks:
     - name: Make sure we can connect to MySQL via Unix socket.
-      ansible.builtin.command: "mysql -u root -proot -e 'show databases;'"
+      command: "mysql -u root -proot -e 'show databases;'"
       changed_when: false
 
     - name: Make sure we can connect to MySQL via TCP.
-      ansible.builtin.command: "mysql -u root -proot -h 127.0.0.1 -e 'show databases;'"
+      command: "mysql -u root -proot -h 127.0.0.1 -e 'show databases;'"
       changed_when: false

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,12 +1,12 @@
 ---
 - name: Get MySQL version.
-  ansible.builtin.command: 'mysql --version'
+  command: 'mysql --version'
   register: mysql_cli_version
   changed_when: false
   check_mode: false
 
 - name: Copy my.cnf global MySQL configuration.
-  ansible.builtin.template:
+  template:
     src: my.cnf.j2
     dest: "{{ mysql_config_file }}"
     owner: root
@@ -16,7 +16,7 @@
   notify: restart mysql
 
 - name: Verify mysql include directory exists.
-  ansible.builtin.file:
+  file:
     path: "{{ mysql_config_include_dir }}"
     state: directory
     owner: root
@@ -25,7 +25,7 @@
   when: mysql_config_include_files | length
 
 - name: Copy my.cnf override files into include directory.
-  ansible.builtin.template:
+  template:
     src: "{{ item.src }}"
     dest: "{{ mysql_config_include_dir }}/{{ item.src | basename }}"
     owner: root
@@ -36,13 +36,13 @@
   notify: restart mysql
 
 - name: Create slow query log file (if configured).
-  ansible.builtin.command: "touch {{ mysql_slow_query_log_file }}"
+  command: "touch {{ mysql_slow_query_log_file }}"
   args:
     creates: "{{ mysql_slow_query_log_file }}"
   when: mysql_slow_query_log_enabled
 
 - name: Create datadir if it does not exist
-  ansible.builtin.file:
+  file:
     path: "{{ mysql_datadir }}"
     state: directory
     owner: mysql
@@ -51,7 +51,7 @@
     setype: mysqld_db_t
 
 - name: Set ownership on slow query log file (if configured).
-  ansible.builtin.file:
+  file:
     path: "{{ mysql_slow_query_log_file }}"
     state: file
     owner: mysql
@@ -60,7 +60,7 @@
   when: mysql_slow_query_log_enabled
 
 - name: Create error log file (if configured).
-  ansible.builtin.command: "touch {{ mysql_log_error }}"
+  command: "touch {{ mysql_log_error }}"
   args:
     creates: "{{ mysql_log_error }}"
   when:
@@ -69,7 +69,7 @@
   tags: ['skip_ansible_galaxy']
 
 - name: Set ownership on error log file (if configured).
-  ansible.builtin.file:
+  file:
     path: "{{ mysql_log_error }}"
     state: file
     owner: mysql
@@ -81,7 +81,7 @@
   tags: ['skip_ansible_galaxy']
 
 - name: Ensure MySQL is started and enabled on boot.
-  ansible.builtin.service:
+  service:
     name: "{{ mysql_daemon }}"
     state: started
     enabled: "{{ mysql_enabled_on_startup }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,26 +1,26 @@
 ---
 # Variable configuration.
-- ansible.builtin.include_tasks: variables.yml
+- include_tasks: variables.yml
 
 # Setup/install tasks.
-- ansible.builtin.include_tasks: setup-RedHat.yml
+- include_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 
-- ansible.builtin.include_tasks: setup-Debian.yml
+- include_tasks: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
-- ansible.builtin.include_tasks: setup-Archlinux.yml
+- include_tasks: setup-Archlinux.yml
   when: ansible_os_family == 'Archlinux'
 
 - name: Check if MySQL packages were installed.
-  ansible.builtin.set_fact:
+  set_fact:
     mysql_install_packages: "{{ (rh_mysql_install_packages is defined and rh_mysql_install_packages.changed)
       or (deb_mysql_install_packages is defined and deb_mysql_install_packages.changed)
       or (arch_mysql_install_packages is defined and arch_mysql_install_packages.changed) }}"
 
 # Configure MySQL.
-- ansible.builtin.include_tasks: configure.yml
-- ansible.builtin.include_tasks: secure-installation.yml
-- ansible.builtin.include_tasks: databases.yml
-- ansible.builtin.include_tasks: users.yml
-- ansible.builtin.include_tasks: replication.yml
+- include_tasks: configure.yml
+- include_tasks: secure-installation.yml
+- include_tasks: databases.yml
+- include_tasks: users.yml
+- include_tasks: replication.yml

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -10,7 +10,7 @@
 
 # Has to be after the password assignment, for idempotency.
 - name: Copy user-my.cnf file with password credentials.
-  ansible.builtin.template:
+  template:
     src: "user-my.cnf.j2"
     dest: "{{ mysql_user_home }}/.my.cnf"
     owner: "{{ mysql_user_name }}"
@@ -20,13 +20,13 @@
     and (mysql_install_packages | bool or mysql_user_password_update)
 
 - name: Disallow root login remotely
-  ansible.builtin.command: 'mysql -NBe "{{ item }}"'
+  command: 'mysql -NBe "{{ item }}"'
   with_items:
     - DELETE FROM mysql.user WHERE User='{{ mysql_root_username }}' AND Host NOT IN ('localhost', '127.0.0.1', '::1')
   changed_when: false
 
 - name: Get list of hosts for the root user.
-  ansible.builtin.command: mysql -NBe
+  command: mysql -NBe
     "SELECT Host
     FROM mysql.user
     WHERE User = '{{ mysql_root_username }}'
@@ -40,7 +40,7 @@
 # the root password correctly. See: https://goo.gl/MSOejW
 # Set root password for MySQL >= 5.7.x.
 - name: Update MySQL root password for localhost root account (5.7.x).
-  ansible.builtin.shell: >
+  shell: >
     mysql -u root -NBe
     "ALTER USER '{{ mysql_root_username }}'@'{{ item }}'
      IDENTIFIED WITH mysql_native_password BY '{{ mysql_root_password }}'; FLUSH PRIVILEGES;"
@@ -51,7 +51,7 @@
 
 # Set root password for MySQL < 5.7.x.
 - name: Update MySQL root password for localhost root account (< 5.7.x).
-  ansible.builtin.shell: >
+  shell: >
     mysql -NBe
     'SET PASSWORD FOR "{{ mysql_root_username }}"@"{{ item }}" = PASSWORD("{{ mysql_root_password }}"); FLUSH PRIVILEGES;'
   with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
@@ -61,7 +61,7 @@
 
 # Has to be after the root password assignment, for idempotency.
 - name: Copy .my.cnf file with root password credentials.
-  ansible.builtin.template:
+  template:
     src: "root-my.cnf.j2"
     dest: "{{ mysql_root_home }}/.my.cnf"
     owner: root
@@ -70,7 +70,7 @@
   when: mysql_install_packages | bool or mysql_root_password_update
 
 - name: Get list of hosts for the anonymous user.
-  ansible.builtin.command: mysql -NBe "SELECT Host FROM mysql.user WHERE User = ''"
+  command: mysql -NBe "SELECT Host FROM mysql.user WHERE User = ''"
   register: mysql_anonymous_hosts
   changed_when: false
   check_mode: false

--- a/tasks/setup-Archlinux.yml
+++ b/tasks/setup-Archlinux.yml
@@ -11,6 +11,6 @@
   register: arch_mysql_install_packages
 
 - name: Run mysql_install_db if MySQL packages were changed.
-  ansible.builtin.command: mysql_install_db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
+  command: mysql_install_db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
   when: arch_mysql_install_packages.changed
   tags: ['skip_ansible_lint']

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,22 +1,22 @@
 ---
 - name: Check if MySQL is already installed.
-  ansible.builtin.stat:
+  stat:
     path: "{{ mysql_config_file }}"
   register: mysql_installed
 
 - name: Update apt cache if MySQL is not yet installed.
-  ansible.builtin.apt:
+  apt:
     update_cache: yes
   changed_when: False
   when: not mysql_installed.stat.exists
 
 - name: Ensure MySQL Python libraries are installed.
-  ansible.builtin.apt:
+  apt:
     name: "{{ mysql_python_package_debian }}"
     state: present
 
 - name: Ensure MySQL packages are installed.
-  ansible.builtin.apt:
+  apt:
     name: "{{ mysql_packages }}"
     state: present
     policy_rc_d: 101
@@ -25,13 +25,13 @@
 # Because Ubuntu starts MySQL as part of the install process, we need to stop
 # mysql and remove the logfiles in case the user set a custom log file size.
 - name: Ensure MySQL is stopped after initial install.
-  ansible.builtin.service:
+  service:
     name: "{{ mysql_daemon }}"
     state: stopped
   when: not mysql_installed.stat.exists
 
 - name: Delete innodb log files created by apt package after initial install.
-  ansible.builtin.file:
+  file:
     path: "{{ mysql_datadir }}/{{ item }}"
     state: absent
   with_items:

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure MySQL packages are installed.
-  ansible.builtin.yum:
+  yum:
     name: "{{ mysql_packages }}"
     state: present
     enablerepo: "{{ mysql_enablerepo | default(omit, true) }}"

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -1,7 +1,7 @@
 ---
 # Variable configuration.
 - name: Include OS-specific variables.
-  ansible.builtin.include_vars: "{{ item }}"
+  include_vars: "{{ item }}"
   with_first_found:
     - files:
         - "vars/{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
@@ -9,51 +9,51 @@
       skip: true
 
 - name: Define mysql_packages.
-  ansible.builtin.set_fact:
+  set_fact:
     mysql_packages: "{{ __mysql_packages | list }}"
   when: mysql_packages is not defined
 
 - name: Define mysql_daemon.
-  ansible.builtin.set_fact:
+  set_fact:
     mysql_daemon: "{{ __mysql_daemon }}"
   when: mysql_daemon is not defined
 
 - name: Define mysql_slow_query_log_file.
-  ansible.builtin.set_fact:
+  set_fact:
     mysql_slow_query_log_file: "{{ __mysql_slow_query_log_file }}"
   when: mysql_slow_query_log_file is not defined
 
 - name: Define mysql_log_error.
-  ansible.builtin.set_fact:
+  set_fact:
     mysql_log_error: "{{ __mysql_log_error }}"
   when: mysql_log_error is not defined
 
 - name: Define mysql_syslog_tag.
-  ansible.builtin.set_fact:
+  set_fact:
     mysql_syslog_tag: "{{ __mysql_syslog_tag }}"
   when: mysql_syslog_tag is not defined
 
 - name: Define mysql_pid_file.
-  ansible.builtin.set_fact:
+  set_fact:
     mysql_pid_file: "{{ __mysql_pid_file }}"
   when: mysql_pid_file is not defined
 
 - name: Define mysql_config_file.
-  ansible.builtin.set_fact:
+  set_fact:
     mysql_config_file: "{{ __mysql_config_file }}"
   when: mysql_config_file is not defined
 
 - name: Define mysql_config_include_dir.
-  ansible.builtin.set_fact:
+  set_fact:
     mysql_config_include_dir: "{{ __mysql_config_include_dir }}"
   when: mysql_config_include_dir is not defined
 
 - name: Define mysql_socket.
-  ansible.builtin.set_fact:
+  set_fact:
     mysql_socket: "{{ __mysql_socket }}"
   when: mysql_socket is not defined
 
 - name: Define mysql_supports_innodb_large_prefix.
-  ansible.builtin.set_fact:
+  set_fact:
     mysql_supports_innodb_large_prefix: "{{ __mysql_supports_innodb_large_prefix }}"
   when: mysql_supports_innodb_large_prefix is not defined


### PR DESCRIPTION
The `ansible.builtin.command` module was removed in Ansible 2.9.6. This PR replaces the use of `ansible.builtin.command` with the `command` module

The `command` module is a more generic module that can be used to execute any command on a remote machine. It has a number of additional features that were not available in the `ansible.builtin.command` module.