### PR TITLE
Support transport security options for users

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -8,5 +8,6 @@
     state: "{{ item.state | default('present') }}"
     append_privs: "{{ item.append_privs | default('no') }}"
     encrypted: "{{ item.encrypted | default('no') }}"
+    tls_requires: "{{ item.tls_requires | default({}) }}"
   with_items: "{{ mysql_users }}"
   no_log: true


### PR DESCRIPTION
Currently there is no way to define transport security options for users. This MR enables passing [tls_requires](https://docs.ansible.com/ansible/latest/collections/community/mysql/mysql_user_module.html#parameter-tls_requires) to `community.mysql.mysql_user`.

Please note, you still have to configure your server to support SSL in the first place. There is a stale MR https://github.com/geerlingguy/ansible-role-mysql/pull/449 for this already but @geerlingguy obviously didn't want to merge it for whatever reason.

On a side note: not having those options in this role and @geerlingguy ignoring important contributions for this role, despite doing a really great and wonderful job with so many other roles, made us rethink our dependency on `geerlingguy.mysql`. We'll go with `debops.mariadb` and `debops.mariadb_server` in the future (supporting MySQL, MariaDB and Percona). Maybe this MR helps other people in the future though.