### PR TITLE
Hide passwords during execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ Replication settings. Set `mysql_server_id` and `mysql_replication_role` by serv
 
 If the replication master has different IP addresses where you are running ansible and where the mysql replica is running, you can *optionally* specify a `mysql_replication_master_inventory_host` to access the machine (e.g. you run ansible on your local machine, but the mysql master and replica need to communicate on a different network)
 
+```yaml
+mysql_hide_passwords: false
+```
+
+Do you need to hide tasks' output which contain passwords during the execution ?
+
 ### Later versions of MySQL on CentOS 7
 
 If you want to install MySQL from the official repository instead of installing the system default MariaDB equivalents, you can add the following `pre_tasks` task in your playbook:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -132,3 +132,5 @@ mysql_replication_master_inventory_host: "{{ mysql_replication_master }}"
 
 # Same keys as `mysql_users` above.
 mysql_replication_user: []
+
+mysql_hide_passwords: false

--- a/tasks/replication.yml
+++ b/tasks/replication.yml
@@ -6,6 +6,7 @@
     password: "{{ mysql_replication_user.password }}"
     priv: "{{ mysql_replication_user.priv | default('*.*:REPLICATION SLAVE,REPLICATION CLIENT') }}"
     state: present
+  no_log: "{{ mysql_hide_passwords }}"
   when:
     - mysql_replication_role == 'master'
     - mysql_replication_user.name is defined
@@ -17,6 +18,7 @@
     mode: getreplica
     login_user: "{{ mysql_root_username }}"
     login_password: "{{ mysql_root_password }}"
+  no_log: "{{ mysql_hide_passwords }}"
   ignore_errors: true
   register: slave
   when:
@@ -43,6 +45,7 @@
     master_password: "{{ mysql_replication_user.password }}"
     master_log_file: "{{ master.File }}"
     master_log_pos: "{{ master.Position }}"
+  no_log: "{{ mysql_hide_passwords }}"
   ignore_errors: true
   when:
     - (slave.Is_Slave is defined and not slave.Is_Slave) or (slave.Is_Replica is defined and not slave.Is_Replica) or (slave.Is_Slave is not defined and slave.Is_Replica is not defined and slave is failed)

--- a/tasks/replication.yml
+++ b/tasks/replication.yml
@@ -26,10 +26,11 @@
     - (mysql_replication_master | length) > 0
   tags: ['skip_ansible_galaxy']
 
+# https://github.com/ansible/ansible/issues/82264
 - name: Check master replication status.
   mysql_replication:
     mode: getprimary
-  delegate_to: "{{ mysql_replication_master_inventory_host }}"
+  delegate_to: "{{ mysql_replication_master_inventory_host | default(omit, true) }}"
   register: master
   when:
     - (slave.Is_Slave is defined and not slave.Is_Slave) or (slave.Is_Replica is defined and not slave.Is_Replica) or (slave.Is_Slave is not defined and slave.Is_Replica is not defined and slave is failed)

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -6,6 +6,7 @@
     password: "{{ mysql_user_password }}"
     priv: '*.*:ALL,GRANT'
     state: present
+  no_log: "{{ mysql_hide_passwords }}"
   when: mysql_user_name != mysql_root_username
 
 # Has to be after the password assignment, for idempotency.
@@ -15,6 +16,7 @@
     dest: "{{ mysql_user_home }}/.my.cnf"
     owner: "{{ mysql_user_name }}"
     mode: 0600
+  no_log: "{{ mysql_hide_passwords }}"
   when: >
     mysql_user_name != mysql_root_username
     and (mysql_install_packages | bool or mysql_user_password_update)
@@ -44,6 +46,7 @@
     mysql -u root -NBe
     "ALTER USER '{{ mysql_root_username }}'@'{{ item }}'
      IDENTIFIED WITH mysql_native_password BY '{{ mysql_root_password }}'; FLUSH PRIVILEGES;"
+  no_log: "{{ mysql_hide_passwords }}"
   with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
   when: >
     ((mysql_install_packages | bool) or mysql_root_password_update)
@@ -54,6 +57,7 @@
   ansible.builtin.shell: >
     mysql -NBe
     'SET PASSWORD FOR "{{ mysql_root_username }}"@"{{ item }}" = PASSWORD("{{ mysql_root_password }}"); FLUSH PRIVILEGES;'
+  no_log: "{{ mysql_hide_passwords }}"
   with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
   when: >
     ((mysql_install_packages | bool) or mysql_root_password_update)
@@ -67,6 +71,7 @@
     owner: root
     group: root
     mode: 0600
+  no_log: "{{ mysql_hide_passwords }}"
   when: mysql_install_packages | bool or mysql_root_password_update
 
 - name: Get list of hosts for the anonymous user.

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -9,4 +9,4 @@
     append_privs: "{{ item.append_privs | default('no') }}"
     encrypted: "{{ item.encrypted | default('no') }}"
   with_items: "{{ mysql_users }}"
-  no_log: true
+  no_log: "{{ mysql_hide_passwords }}"


### PR DESCRIPTION
Hi,

This small pull request allows user to hide current plain-text passwords into execution output with the new variable `mysql_hide_passwords`.
The default value of this variable is `false` to allow users to activate this feature if they need it with a minimal impact on their current usage.

Thank you.