### PR TITLE
Update replication.yml to use "| default(omit, true)" for delegate_to

### DIFF
--- a/tasks/replication.yml
+++ b/tasks/replication.yml
@@ -27,7 +27,7 @@
 - name: Check master replication status.
   mysql_replication:
     mode: getprimary
-  delegate_to: "{{ mysql_replication_master_inventory_host }}"
+  delegate_to: "{{ mysql_replication_master_inventory_host | default(omit, true) }}"
   register: master
   when:
     - (slave.Is_Slave is defined and not slave.Is_Slave) or (slave.Is_Replica is defined and not slave.Is_Replica) or (slave.Is_Slave is not defined and slave.Is_Replica is not defined and slave is failed)


### PR DESCRIPTION
Looks like this was a change in ansible-core 2.16 which results in an error like 

`
fatal: [10.63.4.102 -> {{ mysql_replication_master }}]: FAILED! => {"msg": "Supplied entity must be Host or Group, got <class 'ansible.inventory.host.Host'> instead"}
`

Adding the suggested fix per https://github.com/ansible/ansible/issues/82264