### PR TITLE
Issue #535 : Add column_case_sensitive to mysql_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ The MySQL users and their privileges. A user has the values:
   - `priv` (defaults to `*.*:USAGE`)
   - `append_privs` (defaults to `no`)
   - `state`  (defaults to `present`)
+  - `column_case_sensitive` (defaults to `no`, set `yes` to not uppercase the field names in the privileges)
 
 The formats of these are the same as in the `mysql_user` module.
 

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -8,5 +8,6 @@
     state: "{{ item.state | default('present') }}"
     append_privs: "{{ item.append_privs | default('no') }}"
     encrypted: "{{ item.encrypted | default('no') }}"
+    column_case_sensitive: "{{ item.column_case_sensitive | default('no') }}"
   with_items: "{{ mysql_users }}"
   no_log: "{{ mysql_hide_passwords }}"


### PR DESCRIPTION
This PR addresses issue #535, to add the column_case_sensitive option to mysql_user to handle the case of the field names in the privileges.