### PR TITLE
Set the default Error Log location for Ubuntu

### DIFF
--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,0 +1,2 @@
+---
+__mysql_log_error: /var/log/mysql/error.log


### PR DESCRIPTION
This allows it to be managed by the default logrotate configuration

Fixes #540
