### PR TITLE
Support MySQL 8.4

### DIFF
--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -50,7 +50,7 @@
   with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
   when: >
     ((mysql_install_packages | bool) or mysql_root_password_update)
-    and ('5.7.' in mysql_cli_version.stdout or '8.0.' in mysql_cli_version.stdout)
+    and ('5.7.' in mysql_cli_version.stdout or '8.' in mysql_cli_version.stdout)
 
 # Set root password for MySQL < 5.7.x.
 - name: Update MySQL root password for localhost root account (< 5.7.x).
@@ -61,7 +61,7 @@
   with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
   when: >
     ((mysql_install_packages | bool) or mysql_root_password_update)
-    and ('5.7.' not in mysql_cli_version.stdout and '8.0.' not in mysql_cli_version.stdout)
+    and ('5.7.' not in mysql_cli_version.stdout and '8.' not in mysql_cli_version.stdout)
 
 # Has to be after the root password assignment, for idempotency.
 - name: Copy .my.cnf file with root password credentials.

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -41,6 +41,18 @@
 # Note: We do not use mysql_user for this operation, as it doesn't always update
 # the root password correctly. See: https://goo.gl/MSOejW
 # Set root password for MySQL >= 5.7.x.
+
+- name: Update MySQL root password for localhost root account (8.x).
+  ansible.builtin.shell: >
+    mysql -u root -NBe
+    "ALTER USER '{{ mysql_root_username }}'@'{{ item }}'
+     IDENTIFIED WITH caching_sha2_password BY '{{ mysql_root_password }}'; FLUSH PRIVILEGES;"
+  no_log: "{{ mysql_hide_passwords }}"
+  with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
+  when: >
+    ((mysql_install_packages | bool) or mysql_root_password_update)
+    and ('8.' in mysql_cli_version.stdout)
+
 - name: Update MySQL root password for localhost root account (5.7.x).
   ansible.builtin.shell: >
     mysql -u root -NBe
@@ -50,7 +62,7 @@
   with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
   when: >
     ((mysql_install_packages | bool) or mysql_root_password_update)
-    and ('5.7.' in mysql_cli_version.stdout or '8.' in mysql_cli_version.stdout)
+    and ('5.7.' in mysql_cli_version.stdout)
 
 # Set root password for MySQL < 5.7.x.
 - name: Update MySQL root password for localhost root account (< 5.7.x).

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -87,7 +87,7 @@ read_buffer_size = {{ mysql_read_buffer_size }}
 read_rnd_buffer_size = {{ mysql_read_rnd_buffer_size }}
 myisam_sort_buffer_size = {{ mysql_myisam_sort_buffer_size }}
 thread_cache_size = {{ mysql_thread_cache_size }}
-{% if '8.0.' not in mysql_cli_version.stdout %}
+{% if '8.' not in mysql_cli_version.stdout %}
 query_cache_type = {{ mysql_query_cache_type }}
 query_cache_size = {{ mysql_query_cache_size }}
 query_cache_limit = {{ mysql_query_cache_limit }}
@@ -104,7 +104,7 @@ lower_case_table_names = {{ mysql_lower_case_table_names }}
 event_scheduler = {{ mysql_event_scheduler_state }}
 
 # InnoDB settings.
-{% if mysql_supports_innodb_large_prefix and '8.0.' not in mysql_cli_version.stdout %}
+{% if mysql_supports_innodb_large_prefix and '8.' not in mysql_cli_version.stdout %}
 innodb_large_prefix = {{ mysql_innodb_large_prefix }}
 innodb_file_format = {{ mysql_innodb_file_format }}
 {% endif %}


### PR DESCRIPTION
I've changed the method for resetting the root user password in MySQL 8+ since `mysql_native_password` is no longer enabled by default. Link https://dev.mysql.com/doc/refman/8.4/en/native-pluggable-authentication.html

Now, versions of MySQL 8.* are correctly identified.