### PR TITLE
Allow mysql_config_include_files to contain raw content

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Whether the global my.cnf should be overwritten each time this role is run. Sett
 mysql_config_include_files: []
 ```
 
-A list of files that should override the default global my.cnf. Each item in the array requires a "src" parameter which is a path to a file. An optional "force" parameter can force the file to be updated each time ansible runs.
+A list of files that should override the default global my.cnf. Each item in the array requires either a "src" parameter which is a path to a file, or both a "content" (file contents) and a "dst" (file name) parameter. An optional "force" parameter can force the file to be updated each time ansible runs.
 
 ```yaml
 mysql_databases: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -107,6 +107,9 @@ mysql_log: ""
 mysql_config_include_files: []
 #  - src: path/relative/to/playbook/file.cnf
 #  - { src: path/relative/to/playbook/anotherfile.cnf, force: true }
+#  - content: |
+#      # some included configuration here
+#    dst: yetanotherfile.cnf
 
 # Databases.
 mysql_databases: []

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -31,7 +31,7 @@
     mode: 0755
   when: mysql_config_include_files | length
 
-- name: Copy my.cnf override files into include directory.
+- name: Template my.cnf override files into include directory.
   ansible.builtin.template:
     src: "{{ item.src }}"
     dest: "{{ mysql_config_include_dir }}/{{ item.src | basename }}"
@@ -39,7 +39,22 @@
     group: root
     mode: 0644
     force: "{{ item.force | default(false) }}"
-  with_items: "{{ mysql_config_include_files }}"
+  with_items: "{{ mysql_config_include_files | selectattr('src', 'defined') }}"
+  loop_control:
+    label: "{{ item.src | basename }}"
+  notify: restart mysql
+
+- name: Copy my.cnf override files into include directory.
+  ansible.builtin.copy:
+    content: "{{ item.content }}"
+    dest: "{{ mysql_config_include_dir }}/{{ item.dst }}"
+    owner: root
+    group: root
+    mode: 0644
+    force: "{{ item.force | default(false) }}"
+  with_items: "{{ mysql_config_include_files | selectattr('content', 'defined') }}"
+  loop_control:
+    label: "{{ item.dst }}"
   notify: restart mysql
 
 - name: Create slow query log file (if configured).


### PR DESCRIPTION
# Summary

In some cases, specifying a known src path in `mysql_config_include_files` is not possible / complicated and it may be much cleaner to provide raw file content to be sent. In that case, we need to use the `ansible.builtin.copy` module. We can extend the current implementation by simply filtering on whether `src` or `content` is set in each item in `mysql_config_include_files`

This PR also adds a label definition to the loop, that becomes necessary to avoid printing entire files with the default loop label

# Example

For example if you want to use `mysql_config_include_files` with a file stored inside another role (because that's where it's the most practical place to store it currently), you need to:
```yaml
mysql_config_include_files:
  - { src: "{{ role_path }}/../myrole/files/mysql/myconfig.cnf", force: yes }
```

Instead, for very simple configuration snippets it's cleaner to store them in the inventory / group_vars, and this PR then allows you to do that:
```yaml
mysql_config_include_files:
  - dst: myconfig.cnf
    content: |
      [mysqld]
      # ...
```