### PR TITLE
Introducing the column_case_sensitive for the users task.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ The MySQL users and their privileges. A user has the values:
   - `priv` (defaults to `*.*:USAGE`)
   - `append_privs` (defaults to `no`)
   - `state`  (defaults to `present`)
+  - `case_sensitive` (defaults to `no`)
 
 The formats of these are the same as in the `mysql_user` module.
 
@@ -183,7 +184,7 @@ If you want to install MySQL from the official repository instead of installing 
         name: http://repo.mysql.com/mysql-community-release-el7-5.noarch.rpm
         state: present
       when: ansible_os_family == "RedHat"
-  
+
     - name: Override variables for MySQL (RedHat).
       set_fact:
         mysql_daemon: mysqld

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -8,5 +8,6 @@
     state: "{{ item.state | default('present') }}"
     append_privs: "{{ item.append_privs | default('no') }}"
     encrypted: "{{ item.encrypted | default('no') }}"
+    column_case_sensitive: "{{ item.case_sensitive | default('no') }}"
   with_items: "{{ mysql_users }}"
   no_log: "{{ mysql_hide_passwords }}"


### PR DESCRIPTION
This fixes the warning message: "Option column_case_sensitive is not provided. The default is now false, so the column's name will be uppercased. The default will be changed to true in community.mysql 4.0.0.".

Resolves #535