### PR TITLE
Changing Debian Python package from python3-mysqldb to python3-pymysql.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ mysql_enablerepo: ""
 (RedHat/CentOS only) If you have enabled any additional repositories (might I suggest geerlingguy.repo-epel or geerlingguy.repo-remi), those repositories can be listed under this variable (e.g. `remi,epel`). This can be handy, as an example, if you want to install later versions of MySQL.
 
 ```yaml
-mysql_python_package_debian: python3-mysqldb
+mysql_python_package_debian: python3-pymysql
 ```
 
 (Ubuntu/Debian only) If you need to explicitly override the MySQL Python package, you can set it here. Set this to `python-mysqldb` if using older distributions running Python 2.
@@ -183,7 +183,7 @@ If you want to install MySQL from the official repository instead of installing 
         name: http://repo.mysql.com/mysql-community-release-el7-5.noarch.rpm
         state: present
       when: ansible_os_family == "RedHat"
-  
+
     - name: Override variables for MySQL (RedHat).
       set_fact:
         mysql_daemon: mysqld

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,7 +34,7 @@ mysql_enablerepo: ""
 #   - mysql-server
 #   - MySQL-python
 
-mysql_python_package_debian: python3-mysqldb
+mysql_python_package_debian: python3-pymysql
 
 # MySQL connection settings.
 mysql_port: "3306"


### PR DESCRIPTION
This fixes the deprecation warning given when running the `Remove MySQL test database` task.

Resolves #558