### PR TITLE
Improvement: add missing update_password binding of mysql_user module

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The MySQL users and their privileges. A user has the values:
   - `append_privs` (defaults to `false`)
   - `state`  (defaults to `present`)
   - `case_sensitive` (defaults to `false`)
+  - `update_password` (defaults to `always`)
 
 The formats of these are the same as in the `mysql_user` module.
 

--- a/tasks/replication.yml
+++ b/tasks/replication.yml
@@ -5,6 +5,7 @@
     host: "{{ mysql_replication_user.host | default('%') }}"
     password: "{{ mysql_replication_user.password }}"
     priv: "{{ mysql_replication_user.priv | default('*.*:REPLICATION SLAVE,REPLICATION CLIENT') }}"
+    update_password: "{{ mysql_replication_user.update_password | default('always') }}"
     state: present
   no_log: "{{ mysql_hide_passwords }}"
   when:

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -9,5 +9,6 @@
     append_privs: "{{ item.append_privs | default(false) }}"
     encrypted: "{{ item.encrypted | default(false) }}"
     column_case_sensitive: "{{ item.case_sensitive | default(false) }}"
+    update_password: "{{ item.update_password | default('always') }}"
   with_items: "{{ mysql_users }}"
   no_log: "{{ mysql_hide_passwords }}"


### PR DESCRIPTION
Simple PR for adding a missing attribute binding of the mysql_user module.

(We need this to only initialize user passwords, but do not overwrite them on subsequent runs.)