### PR TITLE
Proposal: Improve mysql_cli_version parsing to make it work with packages from mariadb package sources

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -10,7 +10,7 @@
     - name: Extract MySQL version
       ansible.builtin.set_fact:
         mysql_cli_version: >-
-          {{ (mysql_cli_version.stdout | split(' '))[('mariadb' in (mysql_cli_version.stdout | lower)) | ternary(5, 3)][:-1] }}
+          {{ mysql_cli_version.stdout | regex_search('\d+\.\d+\.\d+(-[a-zA-Z]+)?') }}
 
 - name: Copy my.cnf global MySQL configuration.
   ansible.builtin.template:


### PR DESCRIPTION
### Background
The `mysql_cli_version` variable is extracted by parsing the output of `{{ mysql_daemon }} --version` command.

### Problem
While this does work with our MariaDB v10 installation from the default package sources of Ubuntu 22.04 ...:
output: `mysql  Ver 15.1 Distrib 10.6.18-MariaDB, for debian-linux-gnu (x86_64) using  EditLine wrapper`
... it is broken for a MariaDB v11 installation from the official MariaDB package sources (https://mirror.mariadb.org/repo/11.4/ubuntu/):
output: `mysql from 11.4.5-MariaDB, client 15.2 for debian-linux-gnu (x86_64) using  EditLine wrapper`
The latter results in `fo` being parsed as the `mysql_cli_version`, leading to a failure in the next task due to the string not being able to be compared correctly during config template deployment.

I am not quite sure whether this is the result of MariaDB v11 or the use of the official MariaDB package sources in order to being able to install MariaDB v11 for Ubuntu 22.04.

### Solution proposal
My proposal is to use a regular expression for extraction instead of using fixed offsets.
From my understanding, MySQL outputs its version as `<Major>.<Minor>.<Bugfix>` whereas MariaDB outputs it as `<Major>.<Minor>.<Bugfix>-MariaDB`.

However, I was just able to confirm it working correctly for the combination of Ubuntu and MariaDB. Feel free to improve the regex if some other OS database combinations do not work as expected or if you want to further improve its resilience.