### PR TITLE
fix: query caching features on mariadb

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,9 +67,20 @@ mysql_read_buffer_size: "1M"
 mysql_read_rnd_buffer_size: "4M"
 mysql_myisam_sort_buffer_size: "64M"
 mysql_thread_cache_size: "8"
+
+# Query caching not available on Mysql version ≥ 8.0
+# On MariaDB, behavior changed on version ≥ 10.1.7:
+# * even if query cache usage (`query_cache_type`) is configured, it depends on the configured cache size
+#   (`query_cache_size`), cf. https://mariadb.com/kb/en/server-system-variables/#query_cache_type:
+#   * if you set size to 0, query caching is disabled
+#   * if you set size to non-zero, query caching is enabled
+# * we are unsure of `query_cache_type = 2/DEMAND` behavior
+# * `query_cache_size` and `query_cache_limit` can still be configured and have the same semantics and default values as
+#   their previous MySQL counterparts
 mysql_query_cache_type: "0"
 mysql_query_cache_size: "16M"
 mysql_query_cache_limit: "1M"
+
 mysql_max_connections: "151"
 mysql_tmp_table_size: "16M"
 mysql_max_heap_table_size: "16M"

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -87,7 +87,8 @@ read_buffer_size = {{ mysql_read_buffer_size }}
 read_rnd_buffer_size = {{ mysql_read_rnd_buffer_size }}
 myisam_sort_buffer_size = {{ mysql_myisam_sort_buffer_size }}
 thread_cache_size = {{ mysql_thread_cache_size }}
-{% if mysql_daemon == 'mysql' and mysql_cli_version is version('8.0', '<') %}
+{% if (mysql_daemon == 'mysql' and mysql_cli_version is version('8.0', '<')) or
+      mysql_daemon == 'mariadb' %}
 query_cache_type = {{ mysql_query_cache_type }}
 query_cache_size = {{ mysql_query_cache_size }}
 query_cache_limit = {{ mysql_query_cache_limit }}


### PR DESCRIPTION
Following on this comment in the code : https://github.com/geerlingguy/ansible-role-mysql/commit/e21a22afd48ce2f5e1707ed1875b33ecd162b396#commitcomment-154694645

This reintroduces `query_cache_*` variables for MariaDB users. This disappeared in #561 as I thought at the time it was OK to just remove these variables from MariaDB configuration. I was wrong :D

Thanks,
Regards