### PR TITLE
Improvement: add missing tls_requires binding of mysql_user module

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The MySQL users and their privileges. A user has the values:
   - `state`  (defaults to `present`)
   - `case_sensitive` (defaults to `false`)
   - `update_password` (defaults to `always`)
+  - `tls_requires` (defaults to `{}`)
 
 The formats of these are the same as in the `mysql_user` module.
 

--- a/tasks/replication.yml
+++ b/tasks/replication.yml
@@ -6,6 +6,7 @@
     password: "{{ mysql_replication_user.password }}"
     priv: "{{ mysql_replication_user.priv | default('*.*:REPLICATION SLAVE,REPLICATION CLIENT') }}"
     update_password: "{{ mysql_replication_user.update_password | default('always') }}"
+    tls_requires: "{{ mysql_replication_user.tls_requires | default({}) }}"
     state: present
   no_log: "{{ mysql_hide_passwords }}"
   when:

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -10,5 +10,6 @@
     encrypted: "{{ item.encrypted | default(false) }}"
     column_case_sensitive: "{{ item.case_sensitive | default(false) }}"
     update_password: "{{ item.update_password | default('always') }}"
+    tls_requires: "{{ item.tls_requires | default({}) }}"
   with_items: "{{ mysql_users }}"
   no_log: "{{ mysql_hide_passwords }}"


### PR DESCRIPTION
Simple PR for adding a missing attribute binding of the mysql_user module: `tls_requires`.

This binding allows defining TLS requirements for user-host connections (see [Ansible-Docs](https://docs.ansible.com/ansible/latest/collections/community/mysql/mysql_user_module.html#parameter-tls_requires) for further details).
Defaults to requiring no TLS, which has been the effective default value thus far in absence of the binding.