### PR TITLE
BREAKING CHANGE: make community.mysql collection mandatory. Update related module FQDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,6 @@ On Ubuntu, the package names are named differently, so the `mysql_package` varia
 
 ## Dependencies
 
-If you have `ansible` installed (e.g. `pip3 install ansible`), none.
-
 If you have only installed `ansible-core`, be sure to require `community.mysql` in your `collections/requirements.yml` or install it manually with `ansible-galaxy collection install community.mysql`.
 
 ## Example Playbook

--- a/molecule/default/collections.yml
+++ b/molecule/default/collections.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: community.mysql

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,6 +4,7 @@ dependency:
   name: galaxy
   options:
     ignore-errors: true
+    requirements-file: collections.yml
 driver:
   name: docker
 platforms:

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure MySQL databases are present.
-  mysql_db:
+  community.mysql.mysql_db:
     name: "{{ item.name }}"
     collation: "{{ item.collation | default('utf8_general_ci') }}"
     encoding: "{{ item.encoding | default('utf8') }}"

--- a/tasks/replication.yml
+++ b/tasks/replication.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure replication user exists on master.
-  mysql_user:
+  community.mysql.mysql_user:
     name: "{{ mysql_replication_user.name }}"
     host: "{{ mysql_replication_user.host | default('%') }}"
     password: "{{ mysql_replication_user.password }}"
@@ -15,7 +15,7 @@
   tags: ['skip_ansible_galaxy']
 
 - name: Check slave replication status.
-  mysql_replication:
+  community.mysql.mysql_replication:
     mode: getreplica
     login_user: "{{ mysql_root_username }}"
     login_password: "{{ mysql_root_password }}"
@@ -29,7 +29,7 @@
 
 # https://github.com/ansible/ansible/issues/82264
 - name: Check master replication status.
-  mysql_replication:
+  community.mysql.mysql_replication:
     mode: getprimary
   delegate_to: "{{ mysql_replication_master_inventory_host | default(omit, true) }}"
   register: master
@@ -43,7 +43,7 @@
   tags: ['skip_ansible_galaxy']
 
 - name: Configure replication on the slave.
-  mysql_replication:
+  community.mysql.mysql_replication:
     mode: changeprimary
     master_host: "{{ mysql_replication_master }}"
     master_user: "{{ mysql_replication_user.name }}"
@@ -62,7 +62,7 @@
     - (mysql_replication_master | length) > 0
 
 - name: Start replication.
-  mysql_replication:
+  community.mysql.mysql_replication:
     mode: startreplica
   when:
     - >

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure default user is present.
-  mysql_user:
+  community.mysql.mysql_user:
     name: "{{ mysql_user_name }}"
     host: 'localhost'
     password: "{{ mysql_user_password }}"
@@ -108,13 +108,13 @@
   check_mode: false
 
 - name: Remove anonymous MySQL users.
-  mysql_user:
+  community.mysql.mysql_user:
     name: ""
     host: "{{ item }}"
     state: absent
   with_items: "{{ mysql_anonymous_hosts.stdout_lines|default([]) }}"
 
 - name: Remove MySQL test database.
-  mysql_db:
+  community.mysql.mysql_db:
     name: 'test'
     state: absent

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure MySQL users are present.
-  mysql_user:
+  community.mysql.mysql_user:
     name: "{{ item.name }}"
     host: "{{ item.host | default('localhost') }}"
     password: "{{ item.password }}"


### PR DESCRIPTION
Hi @geerlingguy

I've made this contribution because this role currently fails on the latest version of ansible-core `2.19.0` as well as most common ansible-lint rules.
I also add to set `allow_broken_conditionals = true` in ansible.cfg to deal skip other errors in this version, but this can be dealt later in a dedicated PR.

I've added `BREAKING CHANGE` keyword as conventional commit to signal contributors a major upgrade tag number (in this case, `6.0.0`) should be created after this has been merged into master.
