### PR TITLE
Convert 'ansible_system' to 'ansible_facts.system'

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -17,13 +17,13 @@
       changed_when: false
       failed_when:
         - result.rc != 0 and not (
-            ansible_system == "Linux" and (
+            ansible_facts.system == "Linux" and (
               (mysql_cli_version is version('8.0.34', '>=') and mysql_daemon == 'mysql') or
               (mysql_cli_version is version('10.4', '>=') and mysql_daemon == 'mariadb')
             )
           )
         - result.rc == 0 and (
-            ansible_system == "Linux" and (
+            ansible_facts.system == "Linux" and (
               (mysql_cli_version is version('8.0.34', '>=') and mysql_daemon == 'mysql') or
               (mysql_cli_version is version('10.4', '>=') and mysql_daemon == 'mariadb')
             )
@@ -35,13 +35,13 @@
       changed_when: false
       failed_when:
         - result.rc == 0 and (
-            ansible_system == "Linux" and (
+            ansible_facts.system == "Linux" and (
               (mysql_cli_version is version('8.0.34', '>=') and mysql_daemon == 'mysql') or
               (mysql_cli_version is version('10.4', '>=') and mysql_daemon == 'mariadb')
             )
           )
         - result.rc != 0 and not (
-            ansible_system == "Linux" and (
+            ansible_facts.system == "Linux" and (
               (mysql_cli_version is version('8.0.34', '>=') and mysql_daemon == 'mysql') or
               (mysql_cli_version is version('10.4', '>=') and mysql_daemon == 'mariadb')
             )

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -51,7 +51,7 @@
   with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
   when:
     - (mysql_install_packages | bool) or mysql_root_password_update
-    - ansible_system == "Linux"
+    - ansible_facts.system == "Linux"
     - (mysql_cli_version is version('8.0.34', '>=') and mysql_daemon == 'mysql') or
       (mysql_cli_version is version('10.4', '>=') and mysql_daemon == 'mariadb')
 

--- a/templates/root-my.cnf.j2
+++ b/templates/root-my.cnf.j2
@@ -2,7 +2,7 @@
 
 [client]
 user="{{ mysql_root_username }}"
-{% if ansible_system == "Linux" and (
+{% if ansible_facts.system == "Linux" and (
         (mysql_cli_version is version('8.4', '>=') and mysql_daemon == 'mysql') or
         (mysql_cli_version is version('10.4', '>=') and mysql_daemon == 'mariadb')
       ) %}


### PR DESCRIPTION
Adjust 'ansible_system' to be in line with the new default behavior for ansible-core 2.24