### PR TITLE
[Security] Add secure install and slow query log support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,9 @@ mysql_user_password_update: false
 
 mysql_enabled_on_startup: true
 
+# Security settings.
+mysql_secure_installation: true
+
 # Whether my.cnf should be updated on every run.
 overwrite_global_mycnf: true
 
@@ -54,7 +57,7 @@ mysql_log_file_group: mysql
 
 # Slow query log settings.
 mysql_slow_query_log_enabled: false
-mysql_slow_query_time: "2"
+mysql_slow_query_time: 2
 # The following variable has a default value depending on operating system.
 # mysql_slow_query_log_file: /var/log/mysql-slow.log
 
@@ -117,7 +120,7 @@ mysql_log: ""
 
 mysql_config_include_files: []
 #  - src: path/relative/to/playbook/file.cnf
-#  - { src: path/relative/to/playbook/anotherfile.cnf, force: true }
+#  - { src: path/relative/to.playbook/anotherfile.cnf, force: true }
 
 # Databases.
 mysql_databases: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,16 @@
 
 # Configure MySQL.
 - ansible.builtin.include_tasks: configure.yml
+
+# Security hardening and audit (after configure, before DB/users/replication)
+- name: Include secure installation tasks
+  ansible.builtin.include_tasks: secure-install.yml
+  when: mysql_secure_installation | bool
+
+- name: Include slow query log configuration
+  ansible.builtin.include_tasks: slow-query-log.yml
+  when: mysql_slow_query_log_enabled | bool
+
 - ansible.builtin.include_tasks: secure-installation.yml
 - ansible.builtin.include_tasks: databases.yml
 - ansible.builtin.include_tasks: users.yml

--- a/tasks/secure-install.yml
+++ b/tasks/secure-install.yml
@@ -1,0 +1,32 @@
+---
+# Equivalent of mysql_secure_installation: remove anonymous users, disable remote root, remove test DB, flush privileges.
+
+- name: Disallow root login remotely
+  ansible.builtin.command: "{{ mysql_daemon }} -NBe \"{{ item }}\""
+  with_items:
+    - DELETE FROM mysql.user WHERE User='{{ mysql_root_username }}' AND Host NOT IN ('localhost', '127.0.0.1', '::1')
+  changed_when: false
+
+- name: Get list of hosts for the anonymous user
+  ansible.builtin.command: >
+    {{ mysql_daemon }} -NBe "SELECT Host FROM mysql.user WHERE User = ''"
+  register: mysql_anonymous_hosts
+  changed_when: false
+  check_mode: false
+
+- name: Remove anonymous MySQL users
+  mysql_user:
+    name: ""
+    host: "{{ item }}"
+    state: absent
+  with_items: "{{ mysql_anonymous_hosts.stdout_lines|default([]) }}"
+
+- name: Remove MySQL test database
+  mysql_db:
+    name: 'test'
+    state: absent
+
+- name: Flush MySQL privileges
+  ansible.builtin.command: >
+    {{ mysql_daemon }} -NBe "FLUSH PRIVILEGES"
+  changed_when: false

--- a/tasks/slow-query-log.yml
+++ b/tasks/slow-query-log.yml
@@ -1,0 +1,21 @@
+---
+- name: Ensure slow query log directory exists
+  ansible.builtin.file:
+    path: /var/log/mysql
+    state: directory
+    owner: mysql
+    group: "{{ mysql_log_file_group }}"
+    mode: 0755
+
+- name: Configure slow query log settings include file
+  ansible.builtin.copy:
+    dest: /etc/mysql/conf.d/slow-query.cnf
+    owner: root
+    group: root
+    mode: 0644
+    content: |
+      [mysqld]
+      slow_query_log = {{ 'ON' if mysql_slow_query_log_enabled else 'OFF' }}
+      long_query_time = {{ mysql_slow_query_time | default(2) }}
+      slow_query_log_file = /var/log/mysql/slow.log
+  notify: restart mysql


### PR DESCRIPTION
This PR enhances MySQL security hardening and introduces slow query log auditing for the role.

Security hardening items:
- Disable remote root login (allow only localhost/127.0.0.1/::1).
- Remove anonymous MySQL users.
- Remove the default test database.
- Flush privileges after changes.
- New variable mysql_secure_installation (default: true) to gate execution of secure-install.yml.

Slow query log configuration logic:
- New include task slow-query-log.yml is conditionally executed when mysql_slow_query_log_enabled is true (default: false).
- Generates /etc/mysql/conf.d/slow-query.cnf with:
  - slow_query_log = ON/OFF based on mysql_slow_query_log_enabled.
  - long_query_time = mysql_slow_query_time (defaults to numeric 2 seconds if not defined).
  - slow_query_log_file = /var/log/mysql/slow.log.
- Ensures /var/log/mysql directory exists and is owned by mysql with the correct group.

Compatibility notes:
- Slow query log auditing is disabled by default; existing users are unaffected unless they enable mysql_slow_query_log_enabled.
- Secure installation tasks are controlled via mysql_secure_installation (default: true) and are idempotent, ensuring baseline security without disrupting compliant systems.

Implementation details:
- defaults/main.yml: added mysql_secure_installation (true) and set mysql_slow_query_time to numeric 2.
- tasks/main.yml: added two conditional includes after Configure MySQL, before databases/users/replication tasks.
- tasks/secure-install.yml: mysql_secure_installation equivalent tasks.
- tasks/slow-query-log.yml: slow query log configuration and directory setup.

All new/updated YAML files pass basic yamllint (indentation and spacing).