### PR TITLE
Fix skipped removal of initial logs for Ubuntu

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,7 +4,7 @@
   # become: true
 
   roles:
-    - role: geerlingguy.mysql
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}"
 
   post_tasks:
     - name: Make sure we can connect to MySQL via Unix socket.

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,6 +3,10 @@
   hosts: all
   # become: true
 
+  vars:
+    mysql_config_include_files:
+      - src: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/default/templates/override.cnf"
+
   roles:
     - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}"
 

--- a/molecule/default/templates/override.cnf
+++ b/molecule/default/templates/override.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+innodb_page_size = 32K

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -2,10 +2,14 @@
 - name: Get MySQL version
   block:
     - name: Run mysql --version
-      ansible.builtin.command: '{{ mysql_daemon }} --version'
+      ansible.builtin.command: "{{ mysql_daemon }} --version"
       register: mysql_cli_version
       changed_when: false
       check_mode: false
+
+    - name: Set MariaDB flag.
+      ansible.builtin.set_fact:
+        mysql_is_mariadb: "{{ 'MariaDB' in mysql_cli_version.stdout }}"
 
     - name: Extract MySQL version
       ansible.builtin.set_fact:
@@ -42,14 +46,20 @@
   with_items: "{{ mysql_config_include_files }}"
   notify: restart mysql
 
+- name: Check if datadir exists.
+  ansible.builtin.stat:
+    path: "{{ mysql_datadir }}"
+  register: mysql_datadir_stat
+
 - name: Create datadir if it does not exist
   ansible.builtin.file:
     path: "{{ mysql_datadir }}"
     state: directory
     owner: mysql
     group: mysql
-    mode: 0755
+    mode: "0750"
     setype: mysqld_db_t
+  when: not mysql_datadir_stat.stat.exists
 
 - name: Ensure error log directory exists
   ansible.builtin.file:
@@ -61,6 +71,14 @@
   when:
     - mysql_log_error | default('') | length > 0
     - mysql_log_error != 'syslog'
+
+- name: Initialize MySQL datadir.
+  ansible.builtin.command: >-
+    {{ 'mariadb-install-db --user=mysql --datadir=' + mysql_datadir
+       if mysql_is_mariadb | default(false)
+       else 'mysqld --initialize-insecure --user=mysql' }}
+  when: mysql_initialize_datadir | default(false)
+  changed_when: true
 
 - name: Ensure slow query log file exists and has correct permissions
   ansible.builtin.file:
@@ -86,7 +104,7 @@
     - mysql_log | default('') | length > 0
     - mysql_log_error | default('') | length > 0
     - mysql_log_error != 'syslog'
-  tags: ['skip_ansible_galaxy']
+  tags: ["skip_ansible_galaxy"]
 
 - name: Ensure MySQL is started and enabled on boot.
   ansible.builtin.service:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -23,7 +23,7 @@
   register: deb_mysql_install_packages
 
 # Because Ubuntu starts MySQL as part of the install process, we need to stop
-# mysql and remove the logfiles in case the user set a custom log file size, 
+# mysql and remove the logfiles in case the user set a custom log file size,
 # same holds for ibdata, as innodb settings might conflict with the default ibdata file created.
 - name: Ensure MySQL is stopped after initial install.
   ansible.builtin.service:
@@ -43,4 +43,3 @@
     not mysql_installed.stat.exists
     and ((ansible_facts.distribution == "Debian" and ansible_facts.distribution_major_version | int < 12)
     or ansible_facts.distribution == "Ubuntu")
-

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -23,20 +23,24 @@
   register: deb_mysql_install_packages
 
 # Because Ubuntu starts MySQL as part of the install process, we need to stop
-# mysql and remove the logfiles in case the user set a custom log file size.
+# mysql and remove the logfiles in case the user set a custom log file size, 
+# same holds for ibdata, as innodb settings might conflict with the default ibdata file created.
 - name: Ensure MySQL is stopped after initial install.
   ansible.builtin.service:
     name: "{{ mysql_daemon }}"
     state: stopped
   when: not mysql_installed.stat.exists
 
-- name: Delete innodb log files created by apt package after initial install.
+- name: Delete innodb log files and ibdata created by apt package after initial install.
   ansible.builtin.file:
     path: "{{ mysql_datadir }}/{{ item }}"
     state: absent
   with_items:
     - ib_logfile0
     - ib_logfile1
+    - ibdata1
   when: >
     not mysql_installed.stat.exists
-    and ansible_facts.distribution_major_version | int < 12
+    and ((ansible_facts.distribution == "Debian" and ansible_facts.distribution_major_version | int < 12)
+    or ansible_facts.distribution == "Ubuntu")
+

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -31,15 +31,17 @@
     state: stopped
   when: not mysql_installed.stat.exists
 
-- name: Delete innodb log files and ibdata created by apt package after initial install.
+- name: Remove MySQL datadir to allow clean reinitialization with custom InnoDB settings.
   ansible.builtin.file:
-    path: "{{ mysql_datadir }}/{{ item }}"
+    path: "{{ mysql_datadir }}"
     state: absent
-  with_items:
-    - ib_logfile0
-    - ib_logfile1
-    - ibdata1
-  when: >
-    not mysql_installed.stat.exists
-    and ((ansible_facts.distribution == "Debian" and ansible_facts.distribution_major_version | int < 12)
-    or ansible_facts.distribution == "Ubuntu")
+  when:
+    - not mysql_installed.stat.exists
+    - ansible_facts.os_family == 'Debian'
+
+- name: Set flag to initialize MySQL datadir after config is written.
+  ansible.builtin.set_fact:
+    mysql_initialize_datadir: true
+  when:
+    - not mysql_installed.stat.exists
+    - ansible_facts.os_family == 'Debian'


### PR DESCRIPTION
Currently, the removal of the initial database logfile only works for Debian < 12, as the `distribution_version` comparison is tailored to Debian. 
For reasonably recent Ubuntu versions (e.g., 24), this does not work. However, Ubuntu's apt installation will also create initial log files that have to be removed. 

This PR addresses the issue by adding a check for Ubuntu. Furthermore, the apt installation will also create an initial ibdata-file that might interfere with custom user configuration of InnoDB like `innodb_page_size`. Therefore, this file is deleted as well.